### PR TITLE
jshu: refactor, trim outputs, extend XML outputs and wrapper creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 results/
 *~
 *.bk

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,7 @@ test:
     - bash -c 'cd ./tests/ && bash ./fail_adhocFunctionNamesTest.sh'
     - bash -c 'cd ./tests/ && bash ./fail_jshuSetupTest.sh; [ ${?} -eq 1 ]'
     - bash -c 'cd ./tests/ && bash ./fail_jshuTeardownTest.sh; [ ${?} -eq 1 ]'
+    - bash -c 'cd ./tests/ && bash ./wrapper_unfinishedTest.sh'
   artifacts:
     paths:
       - sample/results/xunit/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,21 @@ stages:
   - package
   - test
 
+apk:
+  stage: package
+  image: alpine:3
+  script:
+    - apk add alpine-sdk
+    - abuild-keygen -a </dev/null
+    - abuild -F checksum
+    - abuild -F
+    - mkdir -p ./build/
+    - cp -fv /root/packages/*/*/jshu-*.apk ./build/
+    - apk add --allow-untrusted ./build/jshu-*.apk
+  artifacts:
+    paths:
+      - ./build/jshu-*.apk
+
 rpm:
   stage: package
   image: centos:7.6.1810

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,24 @@
+stages:
+  - test
+
+test:
+  stage: test
+  image: alpine:3
+  before_script:
+    - apk add bash bc coreutils
+    - ln -fs /usr/bin/awk /bin/awk
+    - ln -fs /usr/bin/cut /bin/cut
+  script:
+    - bash -c 'cd ./sample/ && bash ./incrbuild_funcTest.sh'
+    - bash -c 'cd ./sample/ && bash ./incrbuild_unitTest.sh; [ ${?} -eq 2 ]'
+    - bash -c 'cd ./sample/ && bash ./wrapper_multipleTest.sh; [ ${?} -eq 4 ]'
+    - bash -c 'cd ./sample/ && bash ./wrapper_singleTest.sh'
+    - bash -c 'cd ./tests/ && bash ./adhocFunctionNamesTest.sh'
+    - bash -c 'cd ./tests/ && bash ./fail_FailAbortTest.sh; [ ${?} -eq 1 ]'
+    - bash -c 'cd ./tests/ && bash ./fail_adhocFunctionNamesTest.sh'
+    - bash -c 'cd ./tests/ && bash ./fail_jshuSetupTest.sh; [ ${?} -eq 1 ]'
+    - bash -c 'cd ./tests/ && bash ./fail_jshuTeardownTest.sh; [ ${?} -eq 1 ]'
+  artifacts:
+    paths:
+      - sample/results/xunit/
+      - tests/results/xunit/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,19 @@
 stages:
+  - package
   - test
+
+rpm:
+  stage: package
+  image: centos:7.6.1810
+  before_script:
+    - yum install -y rpm-build
+  script:
+    - mkdir -p ./build
+    - rpmbuild --define="%_topdir ${PWD}/build"  --define "%_sourcedir ${PWD}" -bb rpm.spec
+    - yum --disablerepo '*' install -y ./build/RPMS/noarch/*.rpm
+  artifacts:
+    paths:
+      - build/RPMS/noarch/
 
 test:
   stage: test

--- a/APKBUILD
+++ b/APKBUILD
@@ -1,0 +1,42 @@
+pkgname=jshu
+pkgver=1.0.0
+pkgrel=20
+pkgdesc="Simplified unit test framework for shell script which produces junit-style xml results file"
+url="https://github.com/AdrianDC/jshu"
+arch="noarch"
+license="BSD"
+depends=""
+depends_dev=""
+makedepends="$depends_dev"
+install=""
+maintainer="Adrian DC <radian.dc@gmail.com>"
+options="!fhs"
+srcdir="$startdir/build"
+source="
+  jshutest.inc
+  wrapper.sh
+  "
+builddir="$startdir/build"
+pkgdir="$startdir/build/pkg"
+
+prepare() {
+  default_prepare
+}
+
+build() {
+  cd "$builddir"
+}
+
+check() {
+  cd "$builddir"
+}
+
+package() {
+  cd "$builddir"
+  mkdir -p "$pkgdir/opt/jshu/"
+  install ./jshutest.inc "$pkgdir/opt/jshu/"
+  install ./wrapper.sh "$pkgdir/opt/jshu"
+}
+
+sha512sums="f3e3f9d0b50dece8d28bb97160f27004e112eab14e469ad0ff43b4ca61624b77badb71292353271bc209e87dc8e97e8cbbc9dd70d13115aa4c36a1a7fbf13777  jshutest.inc
+8168d5a1b29eb0810278ce45f6f786b3211a654cbf27195f66a237f560e1b0fc8c80f752e8f326ebe7a97bab872c15090d153196296da5f44ce975c7ed2ed38e  wrapper.sh"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,8 @@ Version 1.0.0-20
 * Implement optional "test_title" variable in test
 * Support passing a formatted tests suite name
 * Apply shfmt formatting Bash codestyle to all files
+* Enforce faulty result file before proper jshuFinalize call
+* Support wrapper.sh --test handlings with enforced failures
 
 Version 1.0.0-19
 * Removed testcase property (assertions) that Jenkins no longer supports.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,18 @@
+Version 1.0.0-20
+* Add tests duration in tests reports
+* Use the results/xunit path for XML results
+* Refactor XML with timestamps, failures, hostname
+* Return error level in finish steps
+* Use 'Tests.*' naming for XML result files
+* Always adapt the package name to a file name
+* Improve tests outputs with colors and spacing
+* Trim extended and colored chars from execution outputs
+* Extract jshu_errmsg and test_title from the output
+* Handle errors inside test functions and verbose output
+* Implement optional "test_title" variable in test
+* Support passing a formatted tests suite name
+* Apply shfmt formatting Bash codestyle to all files
+
 Version 1.0.0-19
 * Removed testcase property (assertions) that Jenkins no longer supports.
 * Limited elapsed time to 3 decimals because the Jenkins time validation is now broken.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ build numbers in a text file and two different test scripts for it:
     have been tested elsewhere and we now wish to test the operation of the script
     as a whole. Thus, this script provides increment_build.sh with data, runs it,
     and evaluates the resultant data after execution is done.
+
+* wrapper_multipleTest.sh - This test script demonstrates the usage of the JSHU wrapper
+    upon multiple individual and documented tests, resulting in a single xml file,
+    with minimal API interfaces for external projects.
+
+* wrapper_multipleTest.sh - This test script demonstrates the usage of the JSHU wrapper
+    on standalone individual tests, resulting in multiple xml files,
+    with minimal API interfaces for external projects.

--- a/buildnumber.txt
+++ b/buildnumber.txt
@@ -1,4 +1,4 @@
 pkgName: jshu
 version: 1.0.0
-release: 19
-epoch: 19
+release: 20
+epoch: 20

--- a/codestyle.sh
+++ b/codestyle.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Apply shfmt codestyle
+shfmt -i 2 -bn -ci -w \
+  ./codestyle.sh \
+  ./jshutest.inc \
+  ./sample/*.sh \
+  ./tests/*.sh

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -247,6 +247,23 @@ jshuInit() {
   fi
   jshuGetSuiteName "$0" "$1"
 
+  # Prepare JSHU result filename
+  jshu_filename=${jshu_pkgname//./_}
+  jshu_filename=${jshu_filename// /_}
+  jshu_filename="Tests.${jshu_filename}.${jshu_suite}.xml"
+  jshu_filename=$(echo "${jshu_filename}" | sed 's/\xC3\(\xA0\|\xA2\)/a/g;s/\xC3\(\xA8\|\xA9\|\xAA\|\xAB\)/e/g;s/\xC3\(\xB9\|\xBC\)/u/g')
+
+  # Prepare faulty initial result
+  {
+    echo '<?xml version="1.0" encoding="UTF-8" ?>'
+    echo "<testsuite failures=\"1\" errors=\"0\" tests=\"1\" skipped=\"0\" name=\"${jshu_pkgname}.${jshu_suitename}\">"
+    echo "  <testcase name=\"${jshu_pkgname}.${jshu_suitename}\">"
+    echo "    <failure type=\"failure\" message=\"Test failure\">"
+    echo "    </failure>"
+    echo '  </testcase>'
+    echo "</testsuite>"
+  } >"${jshu_resultDir}/${jshu_filename}"
+
   # Get rid of previous test results
   rm -f $jshu_content_file
   >$jshu_content_file
@@ -259,7 +276,6 @@ jshuFinalize() {
   jshu_filename=${jshu_filename// /_}
   jshu_filename="Tests.${jshu_filename}.${jshu_suite}.xml"
   jshu_filename=$(echo "${jshu_filename}" | sed 's/\xC3\(\xA0\|\xA2\)/a/g;s/\xC3\(\xA8\|\xA9\|\xAA\|\xAB\)/e/g;s/\xC3\(\xB9\|\xBC\)/u/g')
-  tests_file="${jshu_resultDir}/${jshu_filename}"
   tests_hostname=${HOSTNAME}
   tests_timestamp=$(date -u +%FT%TZ -d @"${jshu_ts_startTime%.}")
 
@@ -269,7 +285,7 @@ jshuFinalize() {
     echo "<testsuite failures=\"${failed}\" errors=\"$errors\" tests=\"$tests\" skipped=\"${skipped}\" name=\"${jshu_pkgname}.${jshu_suitename}\" hostname=\"${tests_hostname}\" time=\"${total}\" timestamp=\"${tests_timestamp}\">"
     cat "${jshu_content_file}"
     echo "</testsuite>"
-  } >"${tests_file}"
+  } >"${jshu_resultDir}/${jshu_filename}"
   rm -f "${jshu_content_file}"
 
   echo ''

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -454,6 +454,7 @@ jshu_run_test() {
   _jshu_result=$?
 
   # acquire error and title outputs
+  eval $(grep -m 1 'jshu_errmsg=' "${_jshu_rt_script_output}" | sed 's#^+* ##' || echo '')
   eval $(type "${_jshu_rt_func_name}" | grep -m 1 'test_title=' | sed 's#^+* ##' || echo '')
   _jshu_rt_endTime=$(_jshuDate)
 
@@ -491,6 +492,6 @@ jshu_run_test() {
 
   unset _jshu_rt_func_name _jshu_rt_script_output _jshu_rt_test_name
   unset _jshu_rt_startTime _jshu_rt_endTime
-  unset test_title
+  unset jshu_errmsg test_title
   return $_jshu_result
 }

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -237,6 +237,9 @@ jshuInit() {
   # create output folder
   mkdir -p "$jshu_resultDir"
 
+  # Store test suite start time
+  jshu_ts_startTime=$(_jshuDate)
+
   # Set values for package name and suite name
   # for reporting
   if [ "${jshu_pkgname}" == "" ]; then
@@ -257,18 +260,27 @@ jshuFinalize() {
   jshu_filename="Tests.${jshu_filename}.${jshu_suite}.xml"
   jshu_filename=$(echo "${jshu_filename}" | sed 's/\xC3\(\xA0\|\xA2\)/a/g;s/\xC3\(\xA8\|\xA9\|\xAA\|\xAB\)/e/g;s/\xC3\(\xB9\|\xBC\)/u/g')
   tests_file="${jshu_resultDir}/${jshu_filename}"
+  tests_hostname=${HOSTNAME}
+  tests_timestamp=$(date -u +%FT%TZ -d @"${jshu_ts_startTime%.}")
 
   ## testsuite block
+  {
+    echo '<?xml version="1.0" encoding="UTF-8" ?>'
+    echo "<testsuite failures=\"${failed}\" errors=\"$errors\" tests=\"$tests\" skipped=\"${skipped}\" name=\"${jshu_pkgname}.${jshu_suitename}\" hostname=\"${tests_hostname}\" time=\"${total}\" timestamp=\"${tests_timestamp}\">"
+    cat "${jshu_content_file}"
+    echo "</testsuite>"
+  } >"${tests_file}"
+  rm -f "${jshu_content_file}"
 
-  echo "<testsuite failures=\"${failed}\" errors=\"$errors\" tests=\"$tests\" skipped=\"${skipped}\" name=\"${jshu_pkgname}.${jshu_suitename}\" time=\"${total}\">" >"${test_file}"
-  cat $jshu_content_file >>"$test_file"
-  echo "</testsuite>" >>"$test_file"
-  rm -f $jshu_content_file
-  echo
+  echo ''
   let totfail=errors+failed
   echo "-- Number of tests         = ${tests}"
   echo "-- Number of skipped tests = ${skipped}"
   echo "-- Number of failing tests = ${totfail}"
+  echo ''
+
+  unset jshu_ts_startTime
+
   return "${totfail}"
 }
 
@@ -291,9 +303,9 @@ jshuRunTests() {
       fi
     else
       # named function does not exist - now what?
-      jshuRecordResult $jshuFAIL $t "Failed to run $t - test function does not exist"
+      jshuRecordResult "${jshuFAIL}" "${t}" "Failed to run ${t} - test function does not exist" ''
       touch /var/tmp/jshut_$$
-      writeTestContent $t "0" "Test function does not exist in script" /var/tmp/jshut_$$
+      writeTestContent "${t}" '0' 'Test function does not exist in script' '' /var/tmp/jshut_$$
       rm -f /var/tmp/jshut_$$
     fi
   done
@@ -329,6 +341,7 @@ jshuRecordResult() {
   _jshu__rr_test_name=$2
   _jshu_rr_errMsg=$(jshuSafeErrMsg "$3")
   jshu_failure_msg=""
+  jshu_failure_end=""
   echo ''
   case ${_jshu_rr_type} in
     ${jshuPASS})
@@ -338,7 +351,8 @@ jshuRecordResult() {
       if [ -z "$_jshu_rr_errMsg" ]; then
         _jshu_rr_errMsg="Test failure"
       fi
-      jshu_failure_msg="<failure type=\"failure\" message=\"${_jshu_rr_errMsg}\"></failure>"
+      jshu_failure_msg="<failure type=\"failure\" message=\"${_jshu_rr_errMsg}\">"
+      jshu_failure_end='</failure>'
       printf " \033[1;33m%-69s \033[1;37m-> \033[1;31mFAILED\033[0m\n" "${_jshu__rr_test_name}"
       let failed=failed+1
       ;;
@@ -346,7 +360,8 @@ jshuRecordResult() {
       if [ -z "$_jshu_rr_errMsg" ]; then
         _jshu_rr_errMsg="Error found"
       fi
-      jshu_failure_msg="<failure type=\"error\" message=\"${_jshu_rr_errMsg}\"></failure>"
+      jshu_failure_msg="<failure type=\"error\" message=\"${_jshu_rr_errMsg}\">"
+      jshu_failure_end='</failure>'
       printf " \033[1;33m%-69s \033[1;37m-> \033[1;31mFAILED\033[0m\n" "${_jshu__rr_test_name}"
       let errors=errors+1
       ;;
@@ -354,7 +369,8 @@ jshuRecordResult() {
       if [ -z "$_jshu_rr_errMsg" ]; then
         _jshu_rr_errMsg="Test failure"
       fi
-      jshu_failure_msg="<failure type=\"failure\" message=\"${_jshu_rr_errMsg}\"></failure>"
+      jshu_failure_msg="<failure type=\"failure\" message=\"${_jshu_rr_errMsg}\">"
+      jshu_failure_end='</failure>'
       printf " \033[1;33m%-69s \033[1;37m-> \033[1;31mFAILED\033[0m\n" "${_jshu__rr_test_name}"
       let failed=failed+1
       ;;
@@ -362,15 +378,18 @@ jshuRecordResult() {
       if [ -z "$_jshu_rr_errMsg" ]; then
         _jshu_rr_errMsg="Error found"
       fi
-      jshu_failure_msg="<failure type=\"error\" message=\"${_jshu_rr_errMsg}\"></failure>"
+      jshu_failure_msg="<failure type=\"error\" message=\"${_jshu_rr_errMsg}\">"
+      jshu_failure_end='</failure>'
       printf " \033[1;33m%-69s \033[1;37m-> \033[1;31mFAILED\033[0m\n" "${_jshu__rr_test_name}"
       let errors=errors+1
       ;;
     ${jshuSKIP})
       if [ ! -z "$_jshu_rr_errMsg" ]; then
-        jshu_failure_msg="<skipped message=\"${_jshu_rr_errMsg}\"></skipped>"
+        jshu_failure_msg="<skipped message=\"${_jshu_rr_errMsg}\">"
+        jshu_failure_end='</skipped>'
       else
         jshu_failure_msg="<skipped/>"
+        jshu_failure_end=''
       fi
       printf " \033[1;33m%-69s \033[1;37m-> \033[1;36mSKIPPED\033[0m\n" "${_jshu__rr_test_name}"
       let skipped=skipped+1
@@ -384,27 +403,46 @@ jshuRecordResult() {
 writeTestContent() {
   _jshu_wtc_test_name=$1
   _jshu_wtc_time=$2
-  _jshu_wtc_fail=$3
-  _jshu_wtc_outf=$4
+  _jshu_wtc_failure_msg=$3
+  _jshu_wtc_failure_end=$4
+  _jshu_wtc_outf=$5
   if [ -e $_jshu_wtc_outf ]; then
     _jshu_wtc_out=$(<$_jshu_wtc_outf)
   else
     _jshu_wtc_out="No such file ($_jshu_wtc_outf) found. Could not read test output."
   fi
   jshuSafeContent $_jshu_wtc_outf
-  ## testcase tag
-  _jshu_wtc_content="
-    <testcase name=\"$_jshu_wtc_test_name\" time=\"$_jshu_wtc_time\">
-    $_jshu_wtc_fail
+
+  # testcase tag
+  cat >>"${jshu_content_file}" <<EOF
+  <testcase name="${_jshu_wtc_test_name}" time="${_jshu_wtc_time}">
+EOF
+
+  # failure log
+  if [ ! -z "${_jshu_wtc_failure_msg}" ]; then
+    cat >>"${jshu_content_file}" <<EOF
+    ${_jshu_wtc_failure_msg}
+EOF
+    if [ ! -z "${_jshu_wtc_failure_msg}" ]; then
+      cat >>"${jshu_content_file}" <<EOF
+<![CDATA[
+${_jshu_wtc_out}
+]]>
+    ${_jshu_wtc_failure_end}
+EOF
+    fi
+  fi
+
+  # testcase output
+  cat >>"${jshu_content_file}" <<EOF
     <system-out>
 <![CDATA[
-$_jshu_wtc_out
+${_jshu_wtc_out}
 ]]>
     </system-out>
-    </testcase>
-  "
-  echo "$_jshu_wtc_content" >>$jshu_content_file
-  unset _jshu_wtc_test_name _jshu_wtc_time _jshu_wtc_fail _jshu_wtc_outf _jshu_wtc_out _jshu_wtc_content
+  </testcase>
+EOF
+  unset _jshu_wtc_test_name _jshu_wtc_time _jshu_wtc_failure_msg _jshu_wtc_failure_end _jshu_wtc_outf _jshu_wtc_out
 }
 
 # Extract from script list of functions to run tests against.
@@ -436,6 +474,7 @@ jshuExtractTestFunctions() {
 jshu_run_test() {
   #default values
   jshu_failure_msg=""
+  jshu_failure_end=""
   jshu_errmsg="" # can be overridden in the tested function
   test_title=""  # can be overridden in the tested function
 
@@ -488,17 +527,17 @@ jshu_run_test() {
   # figure out the result and record it
   if [ "${_jshu_rt_test_name}" == "jshuSetup" -o "${_jshu_rt_test_name}" == "jshuTeardown" ]; then
     if [ "$_jshu_result" != "0" ]; then
-      jshuRecordResult "${_jshu_result}" "${_jshu_rt_test_name}" "Failed to run ${_jshu_rt_test_name}"
+      jshuRecordResult "${_jshu_result}" "${_jshu_rt_test_name}" "Failed to run ${_jshu_rt_test_name}" "${_jshu_rt_script_output}"
       time=$(echo "scale=3;($_jshu_rt_endTime - $_jshu_rt_startTime)/1" | bc -l)
       total=$(echo "scale=3;($total + $time)/1" | bc -l)
-      writeTestContent "${_jshu_rt_test_name}" "${time}" "${jshu_failure_msg}" "${_jshu_rt_script_output}"
+      writeTestContent "${_jshu_rt_test_name}" "${time}" "${jshu_failure_msg}" "${jshu_failure_end}" "${_jshu_rt_script_output}"
     fi
   else
-    jshuRecordResult "${_jshu_result}" "${_jshu_rt_test_name}" "${jshu_errmsg}"
+    jshuRecordResult "${_jshu_result}" "${_jshu_rt_test_name}" "${jshu_errmsg}" "${_jshu_rt_script_output}"
     let tests=$tests+1
     time=$(echo "scale=3;($_jshu_rt_endTime - $_jshu_rt_startTime)/1" | bc -l)
     total=$(echo "scale=3;($total + $time)/1" | bc -l)
-    writeTestContent "${_jshu_rt_test_name}" "${time}" "${jshu_failure_msg}" "${_jshu_rt_script_output}"
+    writeTestContent "${_jshu_rt_test_name}" "${time}" "${jshu_failure_msg}" "${jshu_failure_end}" "${_jshu_rt_script_output}"
   fi
   rm -f "${_jshu_rt_script_output}"
 

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -170,9 +170,7 @@ jshuGetPkgName() {
     _jshu_curdir=${_jshu_curdir%/*}
     _jshu_parentdir=${_jshu_curdir##*/}
   fi
-  jshu_pkgname=${_jshu_parentdir//./_}
-  # convert embedded ' ' to '_'
-  jshu_pkgname=${jshu_pkgname// /_}
+  jshu_pkgname=${_jshu_parentdir}
   unset _jshu_curdir _jshu_parentdir
 }
 
@@ -254,7 +252,12 @@ jshuInit() {
 
 # Write up the tests result file
 jshuFinalize() {
-  test_file="${jshu_resultDir}/TEST_${jshu_pkgname}.${jshu_suite}.xml"
+  jshu_filename=${jshu_pkgname//./_}
+  jshu_filename=${jshu_filename// /_}
+  jshu_filename="TEST_${jshu_filename}.${jshu_suite}.xml"
+  jshu_filename=$(echo "${jshu_filename}" | sed 's/\xC3\(\xA0\|\xA2\)/a/g;s/\xC3\(\xA8\|\xA9\|\xAA\|\xAB\)/e/g;s/\xC3\(\xB9\|\xBC\)/u/g')
+  tests_file="${jshu_resultDir}/${jshu_filename}"
+
   ## testsuite block
 
   echo "<testsuite failures=\"${failed}\" errors=\"$errors\" tests=\"$tests\" skipped=\"${skipped}\" name=\"${jshu_pkgname}.${jshu_suitename}\" time=\"${total}\">" >"${test_file}"

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -453,6 +453,13 @@ jshu_run_test() {
   [ $? -eq 0 ]
   _jshu_result=$?
 
+  # trim the shell output
+  sed -Ei 's/\x1B\[([0-9]{0,2}(;[0-9]{1,2})?)?[mGK]//g' "${_jshu_rt_script_output}"
+  sed -Ei 's/\x1B\[[0-9]{0,4}[ABCD]//g' "${_jshu_rt_script_output}"
+  sed -Ei 's/\x1B\[\?1034h//g' "${_jshu_rt_script_output}"
+  sed -i 's/.*\x08//g' "${_jshu_rt_script_output}"
+  sed -Ei 's/\x1C//g' "${_jshu_rt_script_output}"
+
   # acquire error and title outputs
   eval $(grep -m 1 'jshu_errmsg=' "${_jshu_rt_script_output}" | sed 's#^+* ##' || echo '')
   eval $(type "${_jshu_rt_func_name}" | grep -m 1 'test_title=' | sed 's#^+* ##' || echo '')

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -131,6 +131,7 @@ fi
 
 jshu_pkgname=""
 jshu_suite=""
+jshu_suitename=""
 jshu_content_file=/var/tmp/jshu_content_${CURPROC}.txt
 jshu_resultDir=""
 ereg=""
@@ -182,14 +183,22 @@ jshuGetSuiteName() {
   # (without the .sh extension) and embedded '.'s
   # converted to '_'s
 
+  # Configure test suite name
+  if [ ! "${2}" == "" ]; then
+    jshu_suitename=${2}
+  else
+    jshu_suitename=${1}
+  fi
+
   # strip off directories
-  _jshu_script_name=${1##*/}
+  _jshu_script_name=${jshu_suitename##*/}
   # strip off ".sh"
   _jshu_base_name=${_jshu_script_name%.sh}
   # convert embedded '.' to '_'
   jshu_suite=${_jshu_base_name//./_}
   # convert embedded ' ' to '_'
   jshu_suite=${jshu_suite// /_}
+
   unset _jshu_base_name _jshu_script_name
 }
 
@@ -235,7 +244,7 @@ jshuInit() {
   if [ "${jshu_pkgname}" == "" ]; then
     jshuGetPkgName
   fi
-  jshuGetSuiteName $0
+  jshuGetSuiteName "$0" "$1"
 
   # Get rid of previous test results
   rm -f $jshu_content_file
@@ -248,7 +257,7 @@ jshuFinalize() {
   test_file="${jshu_resultDir}/TEST_${jshu_pkgname}.${jshu_suite}.xml"
   ## testsuite block
 
-  echo "<testsuite failures=\"${failed}\" errors=\"$errors\" tests=\"$tests\" skipped=\"${skipped}\" name=\"${jshu_pkgname}.${jshu_suite}\" time=\"${total}\">" >"${test_file}"
+  echo "<testsuite failures=\"${failed}\" errors=\"$errors\" tests=\"$tests\" skipped=\"${skipped}\" name=\"${jshu_pkgname}.${jshu_suitename}\" time=\"${total}\">" >"${test_file}"
   cat $jshu_content_file >>"$test_file"
   echo "</testsuite>" >>"$test_file"
   rm -f $jshu_content_file

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -269,6 +269,7 @@ jshuFinalize() {
   echo "-- Number of tests         = ${tests}"
   echo "-- Number of skipped tests = ${skipped}"
   echo "-- Number of failing tests = ${totfail}"
+  return "${totfail}"
 }
 
 jshuRunTests() {

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -21,12 +21,12 @@
 #
 # The meat of the test shell function performs the test. It can do so locally
 # (inside this shell script) or it can call external shell scripts and
-# programs. 
+# programs.
 #
 # Standard out and standard err are captured and included in the
-# xml result report. Also, you may define two variables inside your 
+# xml result report. Also, you may define two variables inside your
 # test function to do a regular expression search of the combined
-# stdout/stderr. If the regular expression is found inside the 
+# stdout/stderr. If the regular expression is found inside the
 # captured stdout/stderr, then the test fails.
 #     ereg - regular expression pattern for Linux egrep(1)
 #     icase - either "" (don't ignore case) or "-i" (ignore case)
@@ -47,13 +47,13 @@
 #    ##############################################################
 #    # initialize testsuite
 #    jshuInit
-#    
+#
 #    # run unit tests in this script
 #    jshuRunTests
-#    
+#
 #    # result summary
 #    jshuFinalize
-#    
+#
 #    echo Done.
 #    echo
 #    let tot=failed+errors
@@ -62,7 +62,7 @@
 # NOTES:
 # * You may wish to set the jshu_pkgname variable to the name you want
 #   it to display for the "package" name at the top of the test script,
-#   otherwise it will default to the name of the directory that the 
+#   otherwise it will default to the name of the directory that the
 #   test script is in (or one above it, if the current directory is
 #   named "test" or "tests").
 # * Junit-style XML Jenkins result files will be written to ./results. You
@@ -113,15 +113,20 @@ jshuSKIP=12
 
 jshuTEST_SKIP="return ${jshuSKIP}"
 
-tests=0; errors=0; failed=0; total=0; skipped=0; content=""
-date_cmd=`which date`
+tests=0
+errors=0
+failed=0
+total=0
+skipped=0
+content=""
+date_cmd=$(which date)
 
 CURPROC=$$
 # If we are in a bash shell, we can use this to get subshell pids.
 # Otherwise, we can only get the parent shell pid (making jshu
 # not capable of nesting test scripts).
-if [ -z ${BASHPID+x} ] || [ -z $BASHPID ] ; then
-    CURPROC=$BASHPID
+if [ -z ${BASHPID+x} ] || [ -z $BASHPID ]; then
+  CURPROC=$BASHPID
 fi
 
 jshu_pkgname=""
@@ -134,17 +139,17 @@ jshuTestFunctions=""
 
 # Determine if date command can recognize %N format specifier.
 _jshuDate() {
-	if [ ! -n "${_jshuDateFormat+x}" ] ; then
-		testdate=`date +%s.%N`
-		nano=${testdate##*.}
-		if [ "$nano" == "%N" ] ; then 
-			# date is broken
-			_jshuDateFormat="+%s.0"
-		else
-			_jshuDateFormat="+%s.%N"
-		fi
-	fi
-	date ${_jshuDateFormat}		
+  if [ ! -n "${_jshuDateFormat+x}" ]; then
+    testdate=$(date +%s.%N)
+    nano=${testdate##*.}
+    if [ "$nano" == "%N" ]; then
+      # date is broken
+      _jshuDateFormat="+%s.0"
+    else
+      _jshuDateFormat="+%s.%N"
+    fi
+  fi
+  date ${_jshuDateFormat}
 }
 
 # package name is parent directory name unless overridden
@@ -155,226 +160,226 @@ _jshuDate() {
 
 # Prepare the package name for the report from the current directory
 jshuGetPkgName() {
-	# create a package name based on the directory your test script
-	# is in (if the current directory is "test" or "tests", then
-	# use the name of the directory above it
-	_jshu_curdir=`pwd`
-	_jshu_parentdir=${_jshu_curdir##*/}
-	if [ $_jshu_parentdir == "test" -o $_jshu_parentdir == "tests" ] ; then
-		_jshu_curdir=${_jshu_curdir%/*}
-		_jshu_parentdir=${_jshu_curdir##*/}
-	fi
-	jshu_pkgname=${_jshu_parentdir//./_}
-	# convert embedded ' ' to '_'
-	jshu_pkgname=${jshu_pkgname// /_}
-	unset _jshu_curdir _jshu_parentdir
+  # create a package name based on the directory your test script
+  # is in (if the current directory is "test" or "tests", then
+  # use the name of the directory above it
+  _jshu_curdir=$(pwd)
+  _jshu_parentdir=${_jshu_curdir##*/}
+  if [ $_jshu_parentdir == "test" -o $_jshu_parentdir == "tests" ]; then
+    _jshu_curdir=${_jshu_curdir%/*}
+    _jshu_parentdir=${_jshu_curdir##*/}
+  fi
+  jshu_pkgname=${_jshu_parentdir//./_}
+  # convert embedded ' ' to '_'
+  jshu_pkgname=${jshu_pkgname// /_}
+  unset _jshu_curdir _jshu_parentdir
 }
 
 # Prepare the suite name for the report from the script name
 jshu_suite=""
 jshuGetSuiteName() {
-	# the "suite" name is simply the name of your script
-	# (without the .sh extension) and embedded '.'s
-	# converted to '_'s
-	
-	# strip off directories
-	_jshu_script_name=${1##*/}
-	# strip off ".sh"
-	_jshu_base_name=${_jshu_script_name%.sh}
-	# convert embedded '.' to '_'
-	jshu_suite=${_jshu_base_name//./_}
-	# convert embedded ' ' to '_'
-	jshu_suite=${jshu_suite// /_}
-	unset _jshu_base_name _jshu_script_name
+  # the "suite" name is simply the name of your script
+  # (without the .sh extension) and embedded '.'s
+  # converted to '_'s
+
+  # strip off directories
+  _jshu_script_name=${1##*/}
+  # strip off ".sh"
+  _jshu_base_name=${_jshu_script_name%.sh}
+  # convert embedded '.' to '_'
+  jshu_suite=${_jshu_base_name//./_}
+  # convert embedded ' ' to '_'
+  jshu_suite=${jshu_suite// /_}
+  unset _jshu_base_name _jshu_script_name
 }
 
 # Prepare the test name for the report from the function name
 jshu_test=""
 jshuGetTestName() {
-	_jshu_test_name=${1}
-	# convert embedded '.' to '_'
-	jshu_test=${_jshu_test_name//./_}
-	# convert embedded ' ' to '_'
-	jshu_test=${jshu_test// /_}
-	unset _jshu_test_name
+  _jshu_test_name=${1}
+  # convert embedded '.' to '_'
+  jshu_test=${_jshu_test_name//./_}
+  # convert embedded ' ' to '_'
+  jshu_test=${jshu_test// /_}
+  unset _jshu_test_name
 }
 
 # Create function stub for one-time setup
 jshuSetup() {
-	:
+  :
 }
 
 # Create function stub for one-time teardown
 jshuTeardown() {
-	:
+  :
 }
 
 # Initialize the test suite
 jshuInit() {
-	# Create our results directory
-	#look for BUILDDIR variable
-	_jshu_blddir=`pwd`
-	if [ -z ${BUILDDIR+x} ]; then 
-		# BUILDDIR is unset
-		jshu_resultDir=${_jshu_blddir}/results
-	else
-		# BUILDDIR is set
-		_jshu_blddir=$BUILDDIR
-		jshu_resultDir=${_jshu_blddir}/results
-	fi
-	# create output folder
-	mkdir -p "$jshu_resultDir" 
-	
-	# Set values for package name and suite name
-	# for reporting
-	if [ "${jshu_pkgname}" == "" ] ; then
-		jshuGetPkgName
-	fi
-	jshuGetSuiteName $0
-	
-	# Get rid of previous test results
-	rm -f $jshu_content_file
-	>$jshu_content_file
-	unset _jshu_blddir
+  # Create our results directory
+  #look for BUILDDIR variable
+  _jshu_blddir=$(pwd)
+  if [ -z ${BUILDDIR+x} ]; then
+    # BUILDDIR is unset
+    jshu_resultDir=${_jshu_blddir}/results
+  else
+    # BUILDDIR is set
+    _jshu_blddir=$BUILDDIR
+    jshu_resultDir=${_jshu_blddir}/results
+  fi
+  # create output folder
+  mkdir -p "$jshu_resultDir"
+
+  # Set values for package name and suite name
+  # for reporting
+  if [ "${jshu_pkgname}" == "" ]; then
+    jshuGetPkgName
+  fi
+  jshuGetSuiteName $0
+
+  # Get rid of previous test results
+  rm -f $jshu_content_file
+  >$jshu_content_file
+  unset _jshu_blddir
 }
 
 # Write up the tests result file
 jshuFinalize() {
-	test_file="${jshu_resultDir}/TEST_${jshu_pkgname}.${jshu_suite}.xml"
-	## testsuite block
-	
-	echo "<testsuite failures=\"${failed}\" errors=\"$errors\" tests=\"$tests\" skipped=\"${skipped}\" name=\"${jshu_pkgname}.${jshu_suite}\" time=\"${total}\">" >"${test_file}"
-	cat $jshu_content_file >>"$test_file"
-	echo "</testsuite>" >>"$test_file"
-	rm -f $jshu_content_file
-	echo
-	let totfail=errors+failed
-	echo "-- Number of tests         = ${tests}"
-	echo "-- Number of skipped tests = ${skipped}"
-	echo "-- Number of failing tests = ${totfail}"
+  test_file="${jshu_resultDir}/TEST_${jshu_pkgname}.${jshu_suite}.xml"
+  ## testsuite block
+
+  echo "<testsuite failures=\"${failed}\" errors=\"$errors\" tests=\"$tests\" skipped=\"${skipped}\" name=\"${jshu_pkgname}.${jshu_suite}\" time=\"${total}\">" >"${test_file}"
+  cat $jshu_content_file >>"$test_file"
+  echo "</testsuite>" >>"$test_file"
+  rm -f $jshu_content_file
+  echo
+  let totfail=errors+failed
+  echo "-- Number of tests         = ${tests}"
+  echo "-- Number of skipped tests = ${skipped}"
+  echo "-- Number of failing tests = ${totfail}"
 }
 
 jshuRunTests() {
-	_jshu_run_curdir=`pwd`
-	if ! jshu_run_test jshuSetup; then
-	    return 1
-	fi
-	_jshu_tests=`jshuExtractTestFunctions $0`
-	if [ -n "$jshuTestFunctions" ]; then
-	    _jshu_tests="$jshuTestFunctions $_jshu_tests"
-	fi
-	for t in $_jshu_tests ; do
-	    if type -t $t &>/dev/null; then
-            cd "${_jshu_run_curdir}"
-            jshu_run_test $t
-            rslt=$?
-            if [ $rslt -eq ${jshuFAILABORT} -o $rslt -eq ${jshuERRORABORT} ]; then
-                break
-            fi
-        else
-            # named function does not exist - now what?
-            jshuRecordResult $jshuFAIL $t "Failed to run $t - test function does not exist"
-            touch /var/tmp/jshut_$$
-            writeTestContent $t "0" "Test function does not exist in script" /var/tmp/jshut_$$
-            rm -f /var/tmp/jshut_$$
-        fi
-	done
-	if ! jshu_run_test jshuTeardown; then
-	    return 1
-	fi
-	unset _jshu_tests _jshu_run_curdir
+  _jshu_run_curdir=$(pwd)
+  if ! jshu_run_test jshuSetup; then
+    return 1
+  fi
+  _jshu_tests=$(jshuExtractTestFunctions $0)
+  if [ -n "$jshuTestFunctions" ]; then
+    _jshu_tests="$jshuTestFunctions $_jshu_tests"
+  fi
+  for t in $_jshu_tests; do
+    if type -t $t &>/dev/null; then
+      cd "${_jshu_run_curdir}"
+      jshu_run_test $t
+      rslt=$?
+      if [ $rslt -eq ${jshuFAILABORT} -o $rslt -eq ${jshuERRORABORT} ]; then
+        break
+      fi
+    else
+      # named function does not exist - now what?
+      jshuRecordResult $jshuFAIL $t "Failed to run $t - test function does not exist"
+      touch /var/tmp/jshut_$$
+      writeTestContent $t "0" "Test function does not exist in script" /var/tmp/jshut_$$
+      rm -f /var/tmp/jshut_$$
+    fi
+  done
+  if ! jshu_run_test jshuTeardown; then
+    return 1
+  fi
+  unset _jshu_tests _jshu_run_curdir
 }
 
 # replace embedded quotes in error message with html entity
 jshuSafeErrMsg() {
-    _jshu_safe_errmsg="$1"
-    _jshu_q="&quot;"
-	# convert embedded '"' to '&quot;'
-	_jshu_safe_errmsg=${_jshu_safe_errmsg//\"/$_jshu_q}
-	echo "${_jshu_safe_errmsg}"
-	unset _jshu_safe_errmsg
+  _jshu_safe_errmsg="$1"
+  _jshu_q="&quot;"
+  # convert embedded '"' to '&quot;'
+  _jshu_safe_errmsg=${_jshu_safe_errmsg//\"/$_jshu_q}
+  echo "${_jshu_safe_errmsg}"
+  unset _jshu_safe_errmsg
 }
 
 # filter out binary data from stdout/stderr contents
 jshuSafeContent() {
-    _jshu_sc_outf="$1"
-    _jshu_sc_savf="$1.orig"
-    /bin/cp $_jshu_sc_outf $_jshu_sc_savf
-    tr -cd '\11\12\15\40-\176' <$_jshu_sc_savf >$_jshu_wtc_outf
-    unset _jshu_sc_outf _jshu_sc_savf
+  _jshu_sc_outf="$1"
+  _jshu_sc_savf="$1.orig"
+  /bin/cp $_jshu_sc_outf $_jshu_sc_savf
+  tr -cd '\11\12\15\40-\176' <$_jshu_sc_savf >$_jshu_wtc_outf
+  unset _jshu_sc_outf _jshu_sc_savf
 }
 
 # Record the result of a test for later inclusion in the test report
 # (We also do a stdout summary of test name and PASSED/FAILED/SKIPPED)
 jshuRecordResult() {
-	_jshu_rr_type=$1
-    _jshu__rr_test_name=$2
-    _jshu_rr_errMsg=$(jshuSafeErrMsg "$3")
-	jshu_failure_msg=""
-	case ${_jshu_rr_type} in
-		${jshuPASS})
-			printf " %-69s -> PASSED\n" ${_jshu__rr_test_name}
-			;;
-		${jshuFAIL})
-		    if [ -z "$_jshu_rr_errMsg" ] ; then
-		        _jshu_rr_errMsg="Test failure"
-		    fi
-			jshu_failure_msg="<failure type=\"failure\" message=\"${_jshu_rr_errMsg}\"></failure>"
-			printf " %-69s -> FAILED\n" ${_jshu__rr_test_name}
-			let failed=failed+1
-			;;
-		${jshuERROR})
-		    if [ -z "$_jshu_rr_errMsg" ] ; then
-		        _jshu_rr_errMsg="Error found"
-		    fi
-			jshu_failure_msg="<failure type=\"error\" message=\"${_jshu_rr_errMsg}\"></failure>"
-			printf " %-69s -> FAILED\n" ${_jshu__rr_test_name}
-			let errors=errors+1
-			;;
-		${jshuFAILABORT})
-		    if [ -z "$_jshu_rr_errMsg" ] ; then
-		        _jshu_rr_errMsg="Test failure"
-		    fi
-			jshu_failure_msg="<failure type=\"failure\" message=\"${_jshu_rr_errMsg}\"></failure>"
-			printf " %-69s -> FAILED\n" ${_jshu__rr_test_name}
-			let failed=failed+1
-			;;
-		${jshuERRORABORT})
-		    if [ -z "$_jshu_rr_errMsg" ] ; then
-		        _jshu_rr_errMsg="Error found"
-		    fi
-			jshu_failure_msg="<failure type=\"error\" message=\"${_jshu_rr_errMsg}\"></failure>"
-			printf " %-69s -> FAILED\n" ${_jshu__rr_test_name}
-			let errors=errors+1
-			;;
-		${jshuSKIP})
-		    if [ ! -z "$_jshu_rr_errMsg" ] ; then
-			    jshu_failure_msg="<skipped message=\"${_jshu_rr_errMsg}\"></skipped>"
-                    else
-                        jshu_failure_msg="<skipped/>"
-		    fi
-			printf " %-69s -> SKIPPED\n" ${_jshu__rr_test_name}
-			let skipped=skipped+1
-			;;
-	esac
-	unset _jshu_rr_type _jshu__rr_test_name _jshu_rr_errMsg
+  _jshu_rr_type=$1
+  _jshu__rr_test_name=$2
+  _jshu_rr_errMsg=$(jshuSafeErrMsg "$3")
+  jshu_failure_msg=""
+  case ${_jshu_rr_type} in
+    ${jshuPASS})
+      printf " %-69s -> PASSED\n" ${_jshu__rr_test_name}
+      ;;
+    ${jshuFAIL})
+      if [ -z "$_jshu_rr_errMsg" ]; then
+        _jshu_rr_errMsg="Test failure"
+      fi
+      jshu_failure_msg="<failure type=\"failure\" message=\"${_jshu_rr_errMsg}\"></failure>"
+      printf " %-69s -> FAILED\n" ${_jshu__rr_test_name}
+      let failed=failed+1
+      ;;
+    ${jshuERROR})
+      if [ -z "$_jshu_rr_errMsg" ]; then
+        _jshu_rr_errMsg="Error found"
+      fi
+      jshu_failure_msg="<failure type=\"error\" message=\"${_jshu_rr_errMsg}\"></failure>"
+      printf " %-69s -> FAILED\n" ${_jshu__rr_test_name}
+      let errors=errors+1
+      ;;
+    ${jshuFAILABORT})
+      if [ -z "$_jshu_rr_errMsg" ]; then
+        _jshu_rr_errMsg="Test failure"
+      fi
+      jshu_failure_msg="<failure type=\"failure\" message=\"${_jshu_rr_errMsg}\"></failure>"
+      printf " %-69s -> FAILED\n" ${_jshu__rr_test_name}
+      let failed=failed+1
+      ;;
+    ${jshuERRORABORT})
+      if [ -z "$_jshu_rr_errMsg" ]; then
+        _jshu_rr_errMsg="Error found"
+      fi
+      jshu_failure_msg="<failure type=\"error\" message=\"${_jshu_rr_errMsg}\"></failure>"
+      printf " %-69s -> FAILED\n" ${_jshu__rr_test_name}
+      let errors=errors+1
+      ;;
+    ${jshuSKIP})
+      if [ ! -z "$_jshu_rr_errMsg" ]; then
+        jshu_failure_msg="<skipped message=\"${_jshu_rr_errMsg}\"></skipped>"
+      else
+        jshu_failure_msg="<skipped/>"
+      fi
+      printf " %-69s -> SKIPPED\n" ${_jshu__rr_test_name}
+      let skipped=skipped+1
+      ;;
+  esac
+  unset _jshu_rr_type _jshu__rr_test_name _jshu_rr_errMsg
 }
 
 # create the xml for a testcase result and save it
 # to the content file.
-writeTestContent()  {
-	_jshu_wtc_test_name=$1
-	_jshu_wtc_time=$2
-	_jshu_wtc_fail=$3
-	_jshu_wtc_outf=$4
-    if [ -e $_jshu_wtc_outf ] ; then
-		_jshu_wtc_out=$(<$_jshu_wtc_outf)
-	else
-		_jshu_wtc_out="No such file ($_jshu_wtc_outf) found. Could not read test output."
-	fi
-	jshuSafeContent $_jshu_wtc_outf
-	## testcase tag
-	_jshu_wtc_content="
+writeTestContent() {
+  _jshu_wtc_test_name=$1
+  _jshu_wtc_time=$2
+  _jshu_wtc_fail=$3
+  _jshu_wtc_outf=$4
+  if [ -e $_jshu_wtc_outf ]; then
+    _jshu_wtc_out=$(<$_jshu_wtc_outf)
+  else
+    _jshu_wtc_out="No such file ($_jshu_wtc_outf) found. Could not read test output."
+  fi
+  jshuSafeContent $_jshu_wtc_outf
+  ## testcase tag
+  _jshu_wtc_content="
     <testcase name=\"$_jshu_wtc_test_name\" time=\"$_jshu_wtc_time\">
     $_jshu_wtc_fail
     <system-out>
@@ -384,26 +389,24 @@ $_jshu_wtc_out
     </system-out>
     </testcase>
   "
-    echo "$_jshu_wtc_content" >>$jshu_content_file
-    unset _jshu_wtc_test_name _jshu_wtc_time _jshu_wtc_fail _jshu_wtc_outf _jshu_wtc_out _jshu_wtc_content
+  echo "$_jshu_wtc_content" >>$jshu_content_file
+  unset _jshu_wtc_test_name _jshu_wtc_time _jshu_wtc_fail _jshu_wtc_outf _jshu_wtc_out _jshu_wtc_content
 }
 
 # Extract from script list of functions to run tests against.
 # Returns list of function names
-jshuExtractTestFunctions()
-{
-	_jshu_etf_script_=$1	# name of script to extract functions from
-	
-	# extract the lines with test function names, strip of anything besides the
-	# function name, and output everything on a single line.
-	_jshu_etf_regex_='^[ 	]*(function )*[A-Za-z0-9_]*Test *\(\)'
-	egrep "${_jshu_etf_regex_}" "${_jshu_etf_script_}" \
-	  |sed 's/^[^A-Za-z0-9_]*//;s/^function //;s/\([A-Za-z0-9_]*\).*/\1/g' \
-	  |xargs
-	
-	unset _jshu_etf_regex_ _jshu_etf_script_
-}
+jshuExtractTestFunctions() {
+  _jshu_etf_script_=$1 # name of script to extract functions from
 
+  # extract the lines with test function names, strip of anything besides the
+  # function name, and output everything on a single line.
+  _jshu_etf_regex_='^[ 	]*(function )*[A-Za-z0-9_]*Test *\(\)'
+  egrep "${_jshu_etf_regex_}" "${_jshu_etf_script_}" \
+    | sed 's/^[^A-Za-z0-9_]*//;s/^function //;s/\([A-Za-z0-9_]*\).*/\1/g' \
+    | xargs
+
+  unset _jshu_etf_regex_ _jshu_etf_script_
+}
 
 ########################################################################################
 #
@@ -416,55 +419,52 @@ jshuExtractTestFunctions()
 # Stdout and stderr are redirected into a temp file.
 #
 ########################################################################################
-jshu_run_test()
-{
-	#default values
-	jshu_failure_msg=""
-	jshu_errmsg=""	# can be overridden in the tested function
-	
-	#function args
-    _jshu_rt_func_name=$1
-    
-	_jshu_rt_script_output=/var/tmp/jshu${CURPROC}.txt
-	rm -f "${_jshu_rt_script_output}"
-	>"${_jshu_rt_script_output}"
-	jshuGetTestName $_jshu_rt_func_name
-	_jshu_rt_test_name=$jshu_test
-	
-	# run the shell function
-	_jshu_rt_startTime=$(_jshuDate)
-	${_jshu_rt_func_name} &>"${_jshu_rt_script_output}"
-    _jshu_result=$?
-	_jshu_rt_endTime=$(_jshuDate)
-    
-    # look for regex in output for failure
-    if [ $_jshu_result -eq 0 ] ; then
-		if [ -n "$ereg" ]; then
-			H=`cat "${_jshu_rt_script_output}" | sed -e 's/^\([^+]\)/| \1/g' | egrep $icase "$ereg"`
-			[ -n "$H" ] && _jshu_result=1 && jshu_errmsg="Regex Test failure"
-		fi
-	fi
-	
-    # figure out the result and record it
-    if [ "${_jshu_rt_test_name}" == "jshuSetup" -o "${_jshu_rt_test_name}" == "jshuTeardown" ]; then
-        if [ "$_jshu_result" != "0" ]; then
-            jshuRecordResult $_jshu_result ${_jshu_rt_test_name} "Failed to run ${_jshu_rt_test_name}"
-            time=`echo "scale=3;($_jshu_rt_endTime - $_jshu_rt_startTime)/1" | bc -l`
-            total=`echo "scale=3;($total + $time)/1" | bc -l`
-            writeTestContent ${_jshu_rt_test_name} "${time}" "${jshu_failure_msg}" "${_jshu_rt_script_output}"
-        fi
-    else
-        jshuRecordResult $_jshu_result ${_jshu_rt_test_name} "${jshu_errmsg}"
-        let tests=$tests+1
-        time=`echo "scale=3;($_jshu_rt_endTime - $_jshu_rt_startTime)/1" | bc -l`
-        total=`echo "scale=3;($total + $time)/1" | bc -l`
-        writeTestContent ${_jshu_rt_test_name} "${time}" "${jshu_failure_msg}" "${_jshu_rt_script_output}"
+jshu_run_test() {
+  #default values
+  jshu_failure_msg=""
+  jshu_errmsg="" # can be overridden in the tested function
+
+  #function args
+  _jshu_rt_func_name=$1
+
+  _jshu_rt_script_output=/var/tmp/jshu${CURPROC}.txt
+  rm -f "${_jshu_rt_script_output}"
+  >"${_jshu_rt_script_output}"
+  jshuGetTestName $_jshu_rt_func_name
+  _jshu_rt_test_name=$jshu_test
+
+  # run the shell function
+  _jshu_rt_startTime=$(_jshuDate)
+  ${_jshu_rt_func_name} &>"${_jshu_rt_script_output}"
+  _jshu_result=$?
+  _jshu_rt_endTime=$(_jshuDate)
+
+  # look for regex in output for failure
+  if [ $_jshu_result -eq 0 ]; then
+    if [ -n "$ereg" ]; then
+      H=$(cat "${_jshu_rt_script_output}" | sed -e 's/^\([^+]\)/| \1/g' | egrep $icase "$ereg")
+      [ -n "$H" ] && _jshu_result=1 && jshu_errmsg="Regex Test failure"
     fi
-	rm -f "${_jshu_rt_script_output}"
-	
-	unset _jshu_rt_func_name _jshu_rt_script_output _jshu_rt_test_name
-	unset _jshu_rt_startTime _jshu_rt_endTime
-	return $_jshu_result
+  fi
+
+  # figure out the result and record it
+  if [ "${_jshu_rt_test_name}" == "jshuSetup" -o "${_jshu_rt_test_name}" == "jshuTeardown" ]; then
+    if [ "$_jshu_result" != "0" ]; then
+      jshuRecordResult $_jshu_result ${_jshu_rt_test_name} "Failed to run ${_jshu_rt_test_name}"
+      time=$(echo "scale=3;($_jshu_rt_endTime - $_jshu_rt_startTime)/1" | bc -l)
+      total=$(echo "scale=3;($total + $time)/1" | bc -l)
+      writeTestContent ${_jshu_rt_test_name} "${time}" "${jshu_failure_msg}" "${_jshu_rt_script_output}"
+    fi
+  else
+    jshuRecordResult $_jshu_result ${_jshu_rt_test_name} "${jshu_errmsg}"
+    let tests=$tests+1
+    time=$(echo "scale=3;($_jshu_rt_endTime - $_jshu_rt_startTime)/1" | bc -l)
+    total=$(echo "scale=3;($total + $time)/1" | bc -l)
+    writeTestContent ${_jshu_rt_test_name} "${time}" "${jshu_failure_msg}" "${_jshu_rt_script_output}"
+  fi
+  rm -f "${_jshu_rt_script_output}"
+
+  unset _jshu_rt_func_name _jshu_rt_script_output _jshu_rt_test_name
+  unset _jshu_rt_startTime _jshu_rt_endTime
+  return $_jshu_result
 }
-
-

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -228,11 +228,11 @@ jshuInit() {
   _jshu_blddir=$(pwd)
   if [ -z ${BUILDDIR+x} ]; then
     # BUILDDIR is unset
-    jshu_resultDir=${_jshu_blddir}/results
+    jshu_resultDir=${_jshu_blddir}/results/xunit
   else
     # BUILDDIR is set
     _jshu_blddir=$BUILDDIR
-    jshu_resultDir=${_jshu_blddir}/results
+    jshu_resultDir=${_jshu_blddir}/results/xunit
   fi
   # create output folder
   mkdir -p "$jshu_resultDir"

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -254,7 +254,7 @@ jshuInit() {
 jshuFinalize() {
   jshu_filename=${jshu_pkgname//./_}
   jshu_filename=${jshu_filename// /_}
-  jshu_filename="TEST_${jshu_filename}.${jshu_suite}.xml"
+  jshu_filename="Tests.${jshu_filename}.${jshu_suite}.xml"
   jshu_filename=$(echo "${jshu_filename}" | sed 's/\xC3\(\xA0\|\xA2\)/a/g;s/\xC3\(\xA8\|\xA9\|\xAA\|\xAB\)/e/g;s/\xC3\(\xB9\|\xBC\)/u/g')
   tests_file="${jshu_resultDir}/${jshu_filename}"
 

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -247,6 +247,11 @@ jshuInit() {
   fi
   jshuGetSuiteName "$0" "$1"
 
+  # Append test tag to suite name
+  if [ ! -z "${2}" ]; then
+    jshu_suite="${jshu_suite}.${2}"
+  fi
+
   # Prepare JSHU result filename
   jshu_filename=${jshu_pkgname//./_}
   jshu_filename=${jshu_filename// /_}

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -274,6 +274,7 @@ jshuFinalize() {
 
   echo ''
   let totfail=errors+failed
+  echo "-- Duration of tests       = ${total} seconds"
   echo "-- Number of tests         = ${tests}"
   echo "-- Number of skipped tests = ${skipped}"
   echo "-- Number of failing tests = ${totfail}"

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -325,16 +325,17 @@ jshuRecordResult() {
   _jshu__rr_test_name=$2
   _jshu_rr_errMsg=$(jshuSafeErrMsg "$3")
   jshu_failure_msg=""
+  echo ''
   case ${_jshu_rr_type} in
     ${jshuPASS})
-      printf " %-69s -> PASSED\n" "${_jshu__rr_test_name}"
+      printf " \033[1;33m%-69s \033[1;37m-> \033[1;32mPASSED\033[0m\n" "${_jshu__rr_test_name}"
       ;;
     ${jshuFAIL})
       if [ -z "$_jshu_rr_errMsg" ]; then
         _jshu_rr_errMsg="Test failure"
       fi
       jshu_failure_msg="<failure type=\"failure\" message=\"${_jshu_rr_errMsg}\"></failure>"
-      printf " %-69s -> FAILED\n" "${_jshu__rr_test_name}"
+      printf " \033[1;33m%-69s \033[1;37m-> \033[1;31mFAILED\033[0m\n" "${_jshu__rr_test_name}"
       let failed=failed+1
       ;;
     ${jshuERROR})
@@ -342,7 +343,7 @@ jshuRecordResult() {
         _jshu_rr_errMsg="Error found"
       fi
       jshu_failure_msg="<failure type=\"error\" message=\"${_jshu_rr_errMsg}\"></failure>"
-      printf " %-69s -> FAILED\n" "${_jshu__rr_test_name}"
+      printf " \033[1;33m%-69s \033[1;37m-> \033[1;31mFAILED\033[0m\n" "${_jshu__rr_test_name}"
       let errors=errors+1
       ;;
     ${jshuFAILABORT})
@@ -350,7 +351,7 @@ jshuRecordResult() {
         _jshu_rr_errMsg="Test failure"
       fi
       jshu_failure_msg="<failure type=\"failure\" message=\"${_jshu_rr_errMsg}\"></failure>"
-      printf " %-69s -> FAILED\n" "${_jshu__rr_test_name}"
+      printf " \033[1;33m%-69s \033[1;37m-> \033[1;31mFAILED\033[0m\n" "${_jshu__rr_test_name}"
       let failed=failed+1
       ;;
     ${jshuERRORABORT})
@@ -358,7 +359,7 @@ jshuRecordResult() {
         _jshu_rr_errMsg="Error found"
       fi
       jshu_failure_msg="<failure type=\"error\" message=\"${_jshu_rr_errMsg}\"></failure>"
-      printf " %-69s -> FAILED\n" "${_jshu__rr_test_name}"
+      printf " \033[1;33m%-69s \033[1;37m-> \033[1;31mFAILED\033[0m\n" "${_jshu__rr_test_name}"
       let errors=errors+1
       ;;
     ${jshuSKIP})
@@ -367,7 +368,7 @@ jshuRecordResult() {
       else
         jshu_failure_msg="<skipped/>"
       fi
-      printf " %-69s -> SKIPPED\n" "${_jshu__rr_test_name}"
+      printf " \033[1;33m%-69s \033[1;37m-> \033[1;36mSKIPPED\033[0m\n" "${_jshu__rr_test_name}"
       let skipped=skipped+1
       ;;
   esac

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -327,14 +327,14 @@ jshuRecordResult() {
   jshu_failure_msg=""
   case ${_jshu_rr_type} in
     ${jshuPASS})
-      printf " %-69s -> PASSED\n" ${_jshu__rr_test_name}
+      printf " %-69s -> PASSED\n" "${_jshu__rr_test_name}"
       ;;
     ${jshuFAIL})
       if [ -z "$_jshu_rr_errMsg" ]; then
         _jshu_rr_errMsg="Test failure"
       fi
       jshu_failure_msg="<failure type=\"failure\" message=\"${_jshu_rr_errMsg}\"></failure>"
-      printf " %-69s -> FAILED\n" ${_jshu__rr_test_name}
+      printf " %-69s -> FAILED\n" "${_jshu__rr_test_name}"
       let failed=failed+1
       ;;
     ${jshuERROR})
@@ -342,7 +342,7 @@ jshuRecordResult() {
         _jshu_rr_errMsg="Error found"
       fi
       jshu_failure_msg="<failure type=\"error\" message=\"${_jshu_rr_errMsg}\"></failure>"
-      printf " %-69s -> FAILED\n" ${_jshu__rr_test_name}
+      printf " %-69s -> FAILED\n" "${_jshu__rr_test_name}"
       let errors=errors+1
       ;;
     ${jshuFAILABORT})
@@ -350,7 +350,7 @@ jshuRecordResult() {
         _jshu_rr_errMsg="Test failure"
       fi
       jshu_failure_msg="<failure type=\"failure\" message=\"${_jshu_rr_errMsg}\"></failure>"
-      printf " %-69s -> FAILED\n" ${_jshu__rr_test_name}
+      printf " %-69s -> FAILED\n" "${_jshu__rr_test_name}"
       let failed=failed+1
       ;;
     ${jshuERRORABORT})
@@ -358,7 +358,7 @@ jshuRecordResult() {
         _jshu_rr_errMsg="Error found"
       fi
       jshu_failure_msg="<failure type=\"error\" message=\"${_jshu_rr_errMsg}\"></failure>"
-      printf " %-69s -> FAILED\n" ${_jshu__rr_test_name}
+      printf " %-69s -> FAILED\n" "${_jshu__rr_test_name}"
       let errors=errors+1
       ;;
     ${jshuSKIP})
@@ -367,7 +367,7 @@ jshuRecordResult() {
       else
         jshu_failure_msg="<skipped/>"
       fi
-      printf " %-69s -> SKIPPED\n" ${_jshu__rr_test_name}
+      printf " %-69s -> SKIPPED\n" "${_jshu__rr_test_name}"
       let skipped=skipped+1
       ;;
   esac
@@ -432,6 +432,7 @@ jshu_run_test() {
   #default values
   jshu_failure_msg=""
   jshu_errmsg="" # can be overridden in the tested function
+  test_title=""  # can be overridden in the tested function
 
   #function args
   _jshu_rt_func_name=$1
@@ -440,13 +441,22 @@ jshu_run_test() {
   rm -f "${_jshu_rt_script_output}"
   >"${_jshu_rt_script_output}"
   jshuGetTestName $_jshu_rt_func_name
-  _jshu_rt_test_name=$jshu_test
 
   # run the shell function
   _jshu_rt_startTime=$(_jshuDate)
   ${_jshu_rt_func_name} &>"${_jshu_rt_script_output}"
   _jshu_result=$?
+
+  # acquire error and title outputs
+  eval $(type "${_jshu_rt_func_name}" | grep -m 1 'test_title=' | sed 's#^+* ##' || echo '')
   _jshu_rt_endTime=$(_jshuDate)
+
+  if [ ! "${test_title}" == "" ]; then
+    _jshu_rt_test_name=${test_title}
+  else
+    _jshu_rt_test_name=${jshu_test}
+    _jshu_rt_test_name=${_jshu_rt_test_name//_/ }
+  fi
 
   # look for regex in output for failure
   if [ $_jshu_result -eq 0 ]; then
@@ -459,21 +469,22 @@ jshu_run_test() {
   # figure out the result and record it
   if [ "${_jshu_rt_test_name}" == "jshuSetup" -o "${_jshu_rt_test_name}" == "jshuTeardown" ]; then
     if [ "$_jshu_result" != "0" ]; then
-      jshuRecordResult $_jshu_result ${_jshu_rt_test_name} "Failed to run ${_jshu_rt_test_name}"
+      jshuRecordResult "${_jshu_result}" "${_jshu_rt_test_name}" "Failed to run ${_jshu_rt_test_name}"
       time=$(echo "scale=3;($_jshu_rt_endTime - $_jshu_rt_startTime)/1" | bc -l)
       total=$(echo "scale=3;($total + $time)/1" | bc -l)
-      writeTestContent ${_jshu_rt_test_name} "${time}" "${jshu_failure_msg}" "${_jshu_rt_script_output}"
+      writeTestContent "${_jshu_rt_test_name}" "${time}" "${jshu_failure_msg}" "${_jshu_rt_script_output}"
     fi
   else
-    jshuRecordResult $_jshu_result ${_jshu_rt_test_name} "${jshu_errmsg}"
+    jshuRecordResult "${_jshu_result}" "${_jshu_rt_test_name}" "${jshu_errmsg}"
     let tests=$tests+1
     time=$(echo "scale=3;($_jshu_rt_endTime - $_jshu_rt_startTime)/1" | bc -l)
     total=$(echo "scale=3;($total + $time)/1" | bc -l)
-    writeTestContent ${_jshu_rt_test_name} "${time}" "${jshu_failure_msg}" "${_jshu_rt_script_output}"
+    writeTestContent "${_jshu_rt_test_name}" "${time}" "${jshu_failure_msg}" "${_jshu_rt_script_output}"
   fi
   rm -f "${_jshu_rt_script_output}"
 
   unset _jshu_rt_func_name _jshu_rt_script_output _jshu_rt_test_name
   unset _jshu_rt_startTime _jshu_rt_endTime
+  unset test_title
   return $_jshu_result
 }

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -3,7 +3,7 @@
 # Simplified unit test framework for shell script which
 # produces junit-style xml results file (for Jenkins/Hudson).
 #
-# version 1.0.0-19
+# version 1.0.0-20
 #
 # Include this file into your test shellscript using ". /usr/local/include/jshutest.inc"
 # (or whatever path is appropriate to find this file).

--- a/jshutest.inc
+++ b/jshutest.inc
@@ -444,7 +444,13 @@ jshu_run_test() {
 
   # run the shell function
   _jshu_rt_startTime=$(_jshuDate)
-  ${_jshu_rt_func_name} &>"${_jshu_rt_script_output}"
+  (
+    echo ''
+    set -e
+    ${_jshu_rt_func_name} 2>&1 | tee "${_jshu_rt_script_output}"
+    return ${PIPESTATUS[0]}
+  )
+  [ $? -eq 0 ]
   _jshu_result=$?
 
   # acquire error and title outputs

--- a/rpm.spec
+++ b/rpm.spec
@@ -1,0 +1,28 @@
+%define __jar_repack %{nil}
+Name: jshu
+Version: 1.0.0
+Release: 20
+Summary: Simplified unit test framework for shell script which produces junit-style xml results file
+BuildArch: noarch
+License: BSD
+URL: https://github.com/AdrianDC/jshu
+Source0: jshutest.inc
+Source1: wrapper.sh
+
+%description
+Simplified unit test framework for shell script which produces junit-style xml results file (for Jenkins/Hudson).
+
+%install
+mkdir -p %{buildroot}/opt/jshu
+install -m 755 %SOURCE0 %{buildroot}/opt/jshu
+install -m 755 %SOURCE1 %{buildroot}/opt/jshu
+
+%files
+%defattr(-, root, root)
+%dir /opt/jshu
+/opt/jshu/jshutest.inc
+/opt/jshu/wrapper.sh
+%attr(755,root,root) /opt/jshu/jshutest.inc
+%attr(755,root,root) /opt/jshu/wrapper.sh
+
+%changelog

--- a/sample/incrbuild_funcTest.sh
+++ b/sample/incrbuild_funcTest.sh
@@ -1,15 +1,14 @@
-#!/bin/bash 
+#!/bin/bash
 
 # source the unit test for scripts functions
 . ../jshutest.inc
 
-
 # helper function
 # remove host and date lines from buildnumber.txt file
 stripHostDate() {
-	source="$1"
-	dest="$2"
-	grep -v '^BuildHost:' $source | grep -v '^Date' >$dest
+  source="$1"
+  dest="$2"
+  grep -v '^BuildHost:' $source | grep -v '^Date' >$dest
 }
 
 # In this one, we don't source the other script because
@@ -18,57 +17,56 @@ stripHostDate() {
 ##############################################################
 # unit test functions
 emptyBldNumFile_Test() {
-	tmpfiles_used="./ldempty_test.txt ./ldempty_test1.txt"
-	/bin/rm -f $tmpfiles_used
+  tmpfiles_used="./ldempty_test.txt ./ldempty_test1.txt"
+  /bin/rm -f $tmpfiles_used
 
-	./increment_build.sh build ./ldempty_test.txt
-	
-	stripHostDate ./ldempty_test.txt ./ldempty_test1.txt
-	if ! diff ./ldempty_test1.txt data/empty.txt  ; then
-		/bin/rm -f $tmpfiles_used
-		return ${jshuFAIL}
-	fi
-	
-	# cleanup files
-	/bin/rm -f $tmpfiles_used
-	return ${jshuPASS}
+  ./increment_build.sh build ./ldempty_test.txt
+
+  stripHostDate ./ldempty_test.txt ./ldempty_test1.txt
+  if ! diff ./ldempty_test1.txt data/empty.txt; then
+    /bin/rm -f $tmpfiles_used
+    return ${jshuFAIL}
+  fi
+
+  # cleanup files
+  /bin/rm -f $tmpfiles_used
+  return ${jshuPASS}
 }
 
-
 myprodFile_superTest() {
-	tmpfiles_used="./myprod_test.txt ./myprod_test1.txt"
-	/bin/rm -f $tmpfiles_used
-	
-	cp data/myprod.txt ./myprod_test.txt
-	./increment_build.sh super ./myprod_test.txt
-	
-	stripHostDate ./myprod_test.txt ./myprod_test1.txt
-	if ! diff ./myprod_test1.txt data/myprod.sup.txt ; then
-		/bin/rm -f $tmpfiles_used
-		return ${jshuFAIL}
-	fi
-	
-	# cleanup files
-	/bin/rm -f $tmpfiles_used
-	return ${jshuPASS}
+  tmpfiles_used="./myprod_test.txt ./myprod_test1.txt"
+  /bin/rm -f $tmpfiles_used
+
+  cp data/myprod.txt ./myprod_test.txt
+  ./increment_build.sh super ./myprod_test.txt
+
+  stripHostDate ./myprod_test.txt ./myprod_test1.txt
+  if ! diff ./myprod_test1.txt data/myprod.sup.txt; then
+    /bin/rm -f $tmpfiles_used
+    return ${jshuFAIL}
+  fi
+
+  # cleanup files
+  /bin/rm -f $tmpfiles_used
+  return ${jshuPASS}
 }
 
 myprodFile_minorTest() {
-	tmpfiles_used="./myprod_test.txt ./myprod_test1.txt"
-	/bin/rm -f $tmpfiles_used
-	
-	cp data/myprod.txt ./myprod_test.txt
-	./increment_build.sh minor ./myprod_test.txt
-	
-	stripHostDate ./myprod_test.txt ./myprod_test1.txt
-	if ! diff ./myprod_test1.txt data/myprod.min.txt ; then
-		/bin/rm -f $tmpfiles_used
-		return ${jshuFAIL}
-	fi
-	
-	# cleanup files
-	/bin/rm -f $tmpfiles_used
-	return ${jshuPASS}
+  tmpfiles_used="./myprod_test.txt ./myprod_test1.txt"
+  /bin/rm -f $tmpfiles_used
+
+  cp data/myprod.txt ./myprod_test.txt
+  ./increment_build.sh minor ./myprod_test.txt
+
+  stripHostDate ./myprod_test.txt ./myprod_test1.txt
+  if ! diff ./myprod_test1.txt data/myprod.min.txt; then
+    /bin/rm -f $tmpfiles_used
+    return ${jshuFAIL}
+  fi
+
+  # cleanup files
+  /bin/rm -f $tmpfiles_used
+  return ${jshuPASS}
 }
 
 ##############################################################

--- a/sample/incrbuild_unitTest.sh
+++ b/sample/incrbuild_unitTest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 # source the unit test for scripts functions
 . ../jshutest.inc
@@ -7,279 +7,277 @@
 . ./increment_build.sh
 
 jshuSetup() {
-    # set this variable to a space-delimited list of non-standard test function 
-    # names that you want to run as tests. They will run before the *Test 
-    # functions. It will be used by the jshuRunTests function, so if you
-    # want to use it, you should assign the value to it before calling
-    # jshuRunTests in the bottom (boilerplate) section.
-    jshuTestFunctions="parseVersionFunc getBldFileName_noParam"
+  # set this variable to a space-delimited list of non-standard test function
+  # names that you want to run as tests. They will run before the *Test
+  # functions. It will be used by the jshuRunTests function, so if you
+  # want to use it, you should assign the value to it before calling
+  # jshuRunTests in the bottom (boilerplate) section.
+  jshuTestFunctions="parseVersionFunc getBldFileName_noParam"
 }
 
 ##############################################################
 # unit test functions
 parseVersionFunc() {
-	VERSION="1.5.7"
-	parseVersion
-	if [ "$VERSION_SUPER" != "1" ] ; then
-		return ${jshuFAIL}
-	fi
-	if [ "$VERSION_MAJOR" != "5" ] ; then
-		return ${jshuFAIL}
-	fi
-	if [ "$VERSION_MINOR" != "7" ] ; then
-		return ${jshuFAIL}
-	fi
-	return ${jshuPASS}
+  VERSION="1.5.7"
+  parseVersion
+  if [ "$VERSION_SUPER" != "1" ]; then
+    return ${jshuFAIL}
+  fi
+  if [ "$VERSION_MAJOR" != "5" ]; then
+    return ${jshuFAIL}
+  fi
+  if [ "$VERSION_MINOR" != "7" ]; then
+    return ${jshuFAIL}
+  fi
+  return ${jshuPASS}
 }
 
 parseVersionShortTest() {
-	VERSION="1.5"
-	parseVersion
-	echo $VERSION_SUPER.$VERSION_MAJOR.$VERSION_MINOR
-	if [ "$VERSION_SUPER" != "1" ] ; then
-		jshu_errmsg="\$VERSION_SUPER ($VERSION_SUPER) != 1"
-		return ${jshuFAIL}
-	fi
-	if [ "$VERSION_MAJOR" != "5" ] ; then
-		jshu_errmsg="\$VERSION_MAJOR ($VERSION_MAJOR) != 5"
-		return ${jshuFAIL}
-	fi
-	if [ "$VERSION_MINOR" != "" ] ; then
-		jshu_errmsg="\$VERSION_MINOR ($VERSION_MINOR) != \"\""
-		return ${jshuFAIL}
-	fi
-	return ${jshuPASS}
+  VERSION="1.5"
+  parseVersion
+  echo $VERSION_SUPER.$VERSION_MAJOR.$VERSION_MINOR
+  if [ "$VERSION_SUPER" != "1" ]; then
+    jshu_errmsg="\$VERSION_SUPER ($VERSION_SUPER) != 1"
+    return ${jshuFAIL}
+  fi
+  if [ "$VERSION_MAJOR" != "5" ]; then
+    jshu_errmsg="\$VERSION_MAJOR ($VERSION_MAJOR) != 5"
+    return ${jshuFAIL}
+  fi
+  if [ "$VERSION_MINOR" != "" ]; then
+    jshu_errmsg="\$VERSION_MINOR ($VERSION_MINOR) != \"\""
+    return ${jshuFAIL}
+  fi
+  return ${jshuPASS}
 }
 
 incrSuperTest() {
-	VERSION="1.5.7"
-	BUILDNUM=3
-	EPOCH=7003
-	parseVersion
-	incrSuper
-	if [ ${VERSION_SUPER} -ne 2 ] ; then
-		jshu_errmsg="\$VERSION_SUPER ($VERSION_SUPER) != 1"
-		return ${jshuFAIL}
-	fi
-	if [ "$VERSION_MAJOR" != "0" ] ; then
-		jshu_errmsg="\$VERSION_MAJOR ($VERSION_MAJOR) != 0"
-		return ${jshuFAIL}
-	fi
-	if [ "$VERSION_MINOR" != "0" ] ; then
-		jshu_errmsg="\$VERSION_MINOR ($VERSION_MINOR) != 0"
-		return ${jshuFAIL}
-	fi
-	if [ "$BUILDNUM" != "1" ] ; then
-		jshu_errmsg="\$BUILDNUM ($BUILDNUM) != 1"
-		return ${jshuFAIL}
-	fi
-	if [ "$EPOCH" != "7004" ] ; then
-		jshu_errmsg="\$EPOCH ($EPOCH) != 7004"
-		return ${jshuFAIL}
-	fi
-	return ${jshuPASS}
+  VERSION="1.5.7"
+  BUILDNUM=3
+  EPOCH=7003
+  parseVersion
+  incrSuper
+  if [ ${VERSION_SUPER} -ne 2 ]; then
+    jshu_errmsg="\$VERSION_SUPER ($VERSION_SUPER) != 1"
+    return ${jshuFAIL}
+  fi
+  if [ "$VERSION_MAJOR" != "0" ]; then
+    jshu_errmsg="\$VERSION_MAJOR ($VERSION_MAJOR) != 0"
+    return ${jshuFAIL}
+  fi
+  if [ "$VERSION_MINOR" != "0" ]; then
+    jshu_errmsg="\$VERSION_MINOR ($VERSION_MINOR) != 0"
+    return ${jshuFAIL}
+  fi
+  if [ "$BUILDNUM" != "1" ]; then
+    jshu_errmsg="\$BUILDNUM ($BUILDNUM) != 1"
+    return ${jshuFAIL}
+  fi
+  if [ "$EPOCH" != "7004" ]; then
+    jshu_errmsg="\$EPOCH ($EPOCH) != 7004"
+    return ${jshuFAIL}
+  fi
+  return ${jshuPASS}
 }
 
 incrMajorTest() {
-	VERSION="1.5.7"
-	BUILDNUM=3
-	EPOCH=7003
-	parseVersion
-	incrMajor
-	if [ ${VERSION_SUPER} -ne 1 ] ; then
-		jshu_errmsg="\$VERSION_SUPER ($VERSION_SUPER) != 1"
-		return ${jshuFAIL}
-	fi
-	if [ "$VERSION_MAJOR" != "6" ] ; then
-		jshu_errmsg="\$VERSION_MAJOR ($VERSION_MAJOR) != 6"
-		return ${jshuFAIL}
-	fi
-	if [ "$VERSION_MINOR" != "0" ] ; then
-		jshu_errmsg="\$VERSION_MINOR ($VERSION_MINOR) != 0"
-		return ${jshuFAIL}
-	fi
-	if [ "$BUILDNUM" != "1" ] ; then
-		jshu_errmsg="\$BUILDNUM ($BUILDNUM) != 1"
-		return ${jshuFAIL}
-	fi
-	if [ "$EPOCH" != "7004" ] ; then
-		jshu_errmsg="\$EPOCH ($EPOCH) != 7004"
-		return ${jshuFAIL}
-	fi
-	return ${jshuPASS}
+  VERSION="1.5.7"
+  BUILDNUM=3
+  EPOCH=7003
+  parseVersion
+  incrMajor
+  if [ ${VERSION_SUPER} -ne 1 ]; then
+    jshu_errmsg="\$VERSION_SUPER ($VERSION_SUPER) != 1"
+    return ${jshuFAIL}
+  fi
+  if [ "$VERSION_MAJOR" != "6" ]; then
+    jshu_errmsg="\$VERSION_MAJOR ($VERSION_MAJOR) != 6"
+    return ${jshuFAIL}
+  fi
+  if [ "$VERSION_MINOR" != "0" ]; then
+    jshu_errmsg="\$VERSION_MINOR ($VERSION_MINOR) != 0"
+    return ${jshuFAIL}
+  fi
+  if [ "$BUILDNUM" != "1" ]; then
+    jshu_errmsg="\$BUILDNUM ($BUILDNUM) != 1"
+    return ${jshuFAIL}
+  fi
+  if [ "$EPOCH" != "7004" ]; then
+    jshu_errmsg="\$EPOCH ($EPOCH) != 7004"
+    return ${jshuFAIL}
+  fi
+  return ${jshuPASS}
 }
 
 incrMinorTest() {
-	VERSION="1.5.7"
-	BUILDNUM=3
-	EPOCH=7003
-	parseVersion
-	incrMinor
-	if [ ${VERSION_SUPER} -ne 1 ] ; then
-		jshu_errmsg="\$VERSION_SUPER ($VERSION_SUPER) != 1"
-		return ${jshuFAIL}
-	fi
-	if [ "$VERSION_MAJOR" != "5" ] ; then
-		jshu_errmsg="\$VERSION_MAJOR ($VERSION_MAJOR) != 5"
-		return ${jshuFAIL}
-	fi
-	if [ "$VERSION_MINOR" != "8" ] ; then
-		jshu_errmsg="\$VERSION_MINOR ($VERSION_MINOR) != 8"
-		return ${jshuFAIL}
-	fi
-	if [ "$BUILDNUM" != "1" ] ; then
-		jshu_errmsg="\$BUILDNUM ($BUILDNUM) != 1"
-		return ${jshuFAIL}
-	fi
-	if [ "$EPOCH" != "7004" ] ; then
-		jshu_errmsg="\$EPOCH ($EPOCH) != 7004"
-		return ${jshuFAIL}
-	fi
-	return ${jshuPASS}
+  VERSION="1.5.7"
+  BUILDNUM=3
+  EPOCH=7003
+  parseVersion
+  incrMinor
+  if [ ${VERSION_SUPER} -ne 1 ]; then
+    jshu_errmsg="\$VERSION_SUPER ($VERSION_SUPER) != 1"
+    return ${jshuFAIL}
+  fi
+  if [ "$VERSION_MAJOR" != "5" ]; then
+    jshu_errmsg="\$VERSION_MAJOR ($VERSION_MAJOR) != 5"
+    return ${jshuFAIL}
+  fi
+  if [ "$VERSION_MINOR" != "8" ]; then
+    jshu_errmsg="\$VERSION_MINOR ($VERSION_MINOR) != 8"
+    return ${jshuFAIL}
+  fi
+  if [ "$BUILDNUM" != "1" ]; then
+    jshu_errmsg="\$BUILDNUM ($BUILDNUM) != 1"
+    return ${jshuFAIL}
+  fi
+  if [ "$EPOCH" != "7004" ]; then
+    jshu_errmsg="\$EPOCH ($EPOCH) != 7004"
+    return ${jshuFAIL}
+  fi
+  return ${jshuPASS}
 }
 
 incrBuildTest() {
-	VERSION="1.5.7"
-	BUILDNUM=3
-	EPOCH=7003
-	parseVersion
-	incrBuild
-	if [ ${VERSION_SUPER} -ne 1 ] ; then
-		jshu_errmsg="\$VERSION_SUPER ($VERSION_SUPER) != 1"
-		return ${jshuFAIL}
-	fi
-	if [ "$VERSION_MAJOR" != "5" ] ; then
-		jshu_errmsg="\$VERSION_MAJOR ($VERSION_MAJOR) != 5"
-		return ${jshuFAIL}
-	fi
-	if [ "$VERSION_MINOR" != "7" ] ; then
-		jshu_errmsg="\$VERSION_MINOR ($VERSION_MINOR) != 7"
-		return ${jshuFAIL}
-	fi
-	if [ "$BUILDNUM" != "4" ] ; then
-		jshu_errmsg="\$BUILDNUM ($BUILDNUM) != 4"
-		return ${jshuFAIL}
-	fi
-	if [ "$EPOCH" != "7004" ] ; then
-		jshu_errmsg="\$EPOCH ($EPOCH) != 7004"
-		return ${jshuFAIL}
-	fi
-	return ${jshuPASS}
+  VERSION="1.5.7"
+  BUILDNUM=3
+  EPOCH=7003
+  parseVersion
+  incrBuild
+  if [ ${VERSION_SUPER} -ne 1 ]; then
+    jshu_errmsg="\$VERSION_SUPER ($VERSION_SUPER) != 1"
+    return ${jshuFAIL}
+  fi
+  if [ "$VERSION_MAJOR" != "5" ]; then
+    jshu_errmsg="\$VERSION_MAJOR ($VERSION_MAJOR) != 5"
+    return ${jshuFAIL}
+  fi
+  if [ "$VERSION_MINOR" != "7" ]; then
+    jshu_errmsg="\$VERSION_MINOR ($VERSION_MINOR) != 7"
+    return ${jshuFAIL}
+  fi
+  if [ "$BUILDNUM" != "4" ]; then
+    jshu_errmsg="\$BUILDNUM ($BUILDNUM) != 4"
+    return ${jshuFAIL}
+  fi
+  if [ "$EPOCH" != "7004" ]; then
+    jshu_errmsg="\$EPOCH ($EPOCH) != 7004"
+    return ${jshuFAIL}
+  fi
+  return ${jshuPASS}
 }
 
 getBldFileName_noParam() {
-	bfname=$(getBldNumFilename)
-	if [ "$bfname" != "buildnumber.txt" ] ; then
-		return ${jshuFAIL}
-	fi
-	return ${jshuPASS}
+  bfname=$(getBldNumFilename)
+  if [ "$bfname" != "buildnumber.txt" ]; then
+    return ${jshuFAIL}
+  fi
+  return ${jshuPASS}
 }
 
 getBldFileName_paramTest() {
-	bfname=$(getBldNumFilename mybldnum.txt)
-	if [ "$bfname" != "mybldnum.txt" ] ; then
-		return ${jshuFAIL}
-	fi
-	return ${jshuPASS}
+  bfname=$(getBldNumFilename mybldnum.txt)
+  if [ "$bfname" != "mybldnum.txt" ]; then
+    return ${jshuFAIL}
+  fi
+  return ${jshuPASS}
 }
 
 createBldNumFile_newTest() {
-	tmpfiles_used="./crbldfile_test.txt"
-	/bin/rm -f $tmpfiles_used
-	
-	createBldNumFile ./crbldfile_test.txt
-	if [ ! -e ./crbldfile_test.txt ] ; then
-		jshu_errmsg="[ ! -e ./crbldfile_test.txt ] failed"
-		return ${jshuFAIL}
-	fi
-	/bin/rm -f $tmpfiles_used
-	return ${jshuPASS}
+  tmpfiles_used="./crbldfile_test.txt"
+  /bin/rm -f $tmpfiles_used
+
+  createBldNumFile ./crbldfile_test.txt
+  if [ ! -e ./crbldfile_test.txt ]; then
+    jshu_errmsg="[ ! -e ./crbldfile_test.txt ] failed"
+    return ${jshuFAIL}
+  fi
+  /bin/rm -f $tmpfiles_used
+  return ${jshuPASS}
 }
 
 loadBldNumFile_emptyTest() {
-	tmpfiles_used="./ldbldfile_test.txt"
-	/bin/rm -f $tmpfiles_used
-	
-	createBldNumFile ./ldbldfile_test.txt
-	parseVersion
-	[ ! -e ./ldbldfile_test.txt ] && return ${jshuFAIL}
-	loadBldNumFile ./ldbldfile_test.txt
-	/bin/rm -f $tmpfiles_used
+  tmpfiles_used="./ldbldfile_test.txt"
+  /bin/rm -f $tmpfiles_used
 
-	if [ "${PRODNAME}" = "Unknown product" ] ; then
-		jshu_errmsg="\$PRODNAME ($PRODNAME) != Unknown product"
-		return ${jshuFAIL}
-	fi
-	if [ "$PKGNAME" != "unknown_pkg" ] ; then
-		jshu_errmsg="\$PKGNAME ($PKGNAME) != unknown_pkg"
-		return ${jshuFAIL}
-	fi
-	if [ "$VERSION" != "0.0.0" ] ; then
-		jshu_errmsg="\$VERSION ($VERSION) != 0.0.0"
-		return ${jshuFAIL}
-	fi
-	if [ "$BUILDNUM" != "0" ] ; then
-		jshu_errmsg="\$BUILDNUM ($BUILDNUM) != 0"
-		return ${jshuFAIL}
-	fi
-	if [ "$EPOCH" != "0" ] ; then
-		jshu_errmsg="\$EPOCH ($EPOCH) != 0"
-		return ${jshuFAIL}
-	fi
-	return ${jshuPASS}
+  createBldNumFile ./ldbldfile_test.txt
+  parseVersion
+  [ ! -e ./ldbldfile_test.txt ] && return ${jshuFAIL}
+  loadBldNumFile ./ldbldfile_test.txt
+  /bin/rm -f $tmpfiles_used
+
+  if [ "${PRODNAME}" = "Unknown product" ]; then
+    jshu_errmsg="\$PRODNAME ($PRODNAME) != Unknown product"
+    return ${jshuFAIL}
+  fi
+  if [ "$PKGNAME" != "unknown_pkg" ]; then
+    jshu_errmsg="\$PKGNAME ($PKGNAME) != unknown_pkg"
+    return ${jshuFAIL}
+  fi
+  if [ "$VERSION" != "0.0.0" ]; then
+    jshu_errmsg="\$VERSION ($VERSION) != 0.0.0"
+    return ${jshuFAIL}
+  fi
+  if [ "$BUILDNUM" != "0" ]; then
+    jshu_errmsg="\$BUILDNUM ($BUILDNUM) != 0"
+    return ${jshuFAIL}
+  fi
+  if [ "$EPOCH" != "0" ]; then
+    jshu_errmsg="\$EPOCH ($EPOCH) != 0"
+    return ${jshuFAIL}
+  fi
+  return ${jshuPASS}
 }
 
 loadBldNumFileTest() {
-	tmpfiles_used="./ldbldfile1_test.txt"
-	/bin/rm -f $tmpfiles_used
+  tmpfiles_used="./ldbldfile1_test.txt"
+  /bin/rm -f $tmpfiles_used
 
-	PRODNAME="My sample product"
-	PKGNAME="sample_prod"
-	VERSION="1.2.3"
-	parseVersion
-	BUILDNUM="145"
-	EPOCH="7009125"
-	BUILDHOST="ananke"
-	BUILDDATE="Sun Jan 26 15:57:13 CST 2014"
-	writeBldNumFile ./ldbldfile1_test.txt
-	unset PRODNAME PKGNAME VERSION BUILDNUM EPOCH
-	
-	loadBldNumFile ldbldfile1_test.txt
-	/bin/rm -f $tmpfiles_used
-	if [ "${PRODNAME}" != "My sample product" ] ; then
-		jshu_errmsg="\$PRODNAME ($PRODNAME) != My sample product"
-		return ${jshuFAIL}
-	fi
-	if [ "${PKGNAME}" != "sample_prod" ] ; then
-		jshu_errmsg="\$PKGNAME (${PKGNAME}) != sample_prod"
-		return ${jshuFAIL}
-	fi
-	if [ "${VERSION}" != "1.2.3" ] ; then
-		jshu_errmsg="\$VERSION ($VERSION) != 1.2.3"
-		return ${jshuFAIL}
-	fi
-	if [ "${BUILDNUM}" != "145" ] ; then
-		jshu_errmsg="\$BUILDNUM ($BUILDNUM) != 145"
-		return ${jshuFAIL}
-	fi
-	if [ "${EPOCH}" != "7009125" ] ; then
-		jshu_errmsg="\$EPOCH ($EPOCH) != 7009125"
-		return ${jshuFAIL}
-	fi
-	return ${jshuPASS}
+  PRODNAME="My sample product"
+  PKGNAME="sample_prod"
+  VERSION="1.2.3"
+  parseVersion
+  BUILDNUM="145"
+  EPOCH="7009125"
+  BUILDHOST="ananke"
+  BUILDDATE="Sun Jan 26 15:57:13 CST 2014"
+  writeBldNumFile ./ldbldfile1_test.txt
+  unset PRODNAME PKGNAME VERSION BUILDNUM EPOCH
+
+  loadBldNumFile ldbldfile1_test.txt
+  /bin/rm -f $tmpfiles_used
+  if [ "${PRODNAME}" != "My sample product" ]; then
+    jshu_errmsg="\$PRODNAME ($PRODNAME) != My sample product"
+    return ${jshuFAIL}
+  fi
+  if [ "${PKGNAME}" != "sample_prod" ]; then
+    jshu_errmsg="\$PKGNAME (${PKGNAME}) != sample_prod"
+    return ${jshuFAIL}
+  fi
+  if [ "${VERSION}" != "1.2.3" ]; then
+    jshu_errmsg="\$VERSION ($VERSION) != 1.2.3"
+    return ${jshuFAIL}
+  fi
+  if [ "${BUILDNUM}" != "145" ]; then
+    jshu_errmsg="\$BUILDNUM ($BUILDNUM) != 145"
+    return ${jshuFAIL}
+  fi
+  if [ "${EPOCH}" != "7009125" ]; then
+    jshu_errmsg="\$EPOCH ($EPOCH) != 7009125"
+    return ${jshuFAIL}
+  fi
+  return ${jshuPASS}
 }
 
 badErrorMsgTest() {
-    jshu_errmsg="This is a \" quote mark"
-    ${jshuTEST_SKIP}
+  jshu_errmsg="This is a \" quote mark"
+  ${jshuTEST_SKIP}
 }
 
 unfinishedTest() {
-    jshu_errmsg="This test has not been written yet"
-    ${jshuTEST_SKIP}
+  jshu_errmsg="This test has not been written yet"
+  ${jshuTEST_SKIP}
 }
-
-
 
 ##############################################################
 # main

--- a/sample/increment_build.sh
+++ b/sample/increment_build.sh
@@ -2,7 +2,7 @@
 
 # increment_build.sh
 #
-# This script allows for simple maintenance of an informational text 
+# This script allows for simple maintenance of an informational text
 # file containing information useful for specification in an rpm spec file.
 #
 # For example, one such file might contain:
@@ -16,7 +16,7 @@
 #
 # The BUILDNUM_TXT variable (below) has the name of your buildnumber.txt
 # file (including any necessary directory info). If the
-# BUILDNUM_TXT file does not exist, it will be created 
+# BUILDNUM_TXT file does not exist, it will be created
 # with dummy values. You can then edit the BUILDNUM_TXT
 # file to provide product and package names, etc.
 #
@@ -46,7 +46,7 @@
 #
 # One way you can use this is in the Makefile where you
 # build your rpm. Define the following to get access to
-# the values (add directory info to "buildnumber.txt" 
+# the values (add directory info to "buildnumber.txt"
 # if necessary):
 #   PRODNAME = $(shell /bin/grep ^ProductName: buildnumber.txt | /bin/cut -d: -f2)
 #   PKGNAME = $(shell /bin/grep ^PkgName: buildnumber.txt | /bin/awk '{print $$2}')
@@ -106,185 +106,182 @@ BUILDNUM_TXT=./buildnumber.txt
 #    PRODNAME, PKGNAME, VERSION, BUILDNUM, EPOCH,
 #    BUILDHOST, BUILDDATE
 
-
-
 # get the name of the buildnumber file to use
 getBldNumFilename() {
-	if [ $# -lt 1 ] ; then
-		filename="buildnumber.txt"
-	else
-		filename="$1"
-	fi
-	if [ ! -n "$filename" ] ; then
-		filename="buildnumber.txt"
-	fi
-	echo $filename
-	unset filename
+  if [ $# -lt 1 ]; then
+    filename="buildnumber.txt"
+  else
+    filename="$1"
+  fi
+  if [ ! -n "$filename" ]; then
+    filename="buildnumber.txt"
+  fi
+  echo $filename
+  unset filename
 }
 
 writeBldNumFile() {
-	filename="$1"
-	
-	echo "ProductName:$PRODNAME" >"${filename}"
-	echo "PkgName: $PKGNAME" >>"${filename}"
-	if [ -n "$VERSION_MINOR" ] ; then
-		ver="$VERSION_SUPER.$VERSION_MAJOR.$VERSION_MINOR"
-	else
-		ver="$VERSION_SUPER.$VERSION_MAJOR"
-	fi
-	echo "Version: $ver" >>"${filename}"
-	echo "BuildNumber: $BUILDNUM" >>"${filename}"
-	echo "Epoch: $EPOCH" >>"${filename}"
-	echo "BuildHost: $BUILDHOST" >>"${filename}"
-	echo "Date: $BUILDDATE" >>"${filename}"
-	unset filename ver
+  filename="$1"
+
+  echo "ProductName:$PRODNAME" >"${filename}"
+  echo "PkgName: $PKGNAME" >>"${filename}"
+  if [ -n "$VERSION_MINOR" ]; then
+    ver="$VERSION_SUPER.$VERSION_MAJOR.$VERSION_MINOR"
+  else
+    ver="$VERSION_SUPER.$VERSION_MAJOR"
+  fi
+  echo "Version: $ver" >>"${filename}"
+  echo "BuildNumber: $BUILDNUM" >>"${filename}"
+  echo "Epoch: $EPOCH" >>"${filename}"
+  echo "BuildHost: $BUILDHOST" >>"${filename}"
+  echo "Date: $BUILDDATE" >>"${filename}"
+  unset filename ver
 }
 
-
 parseVersion() {
-	VERSION_SUPER=${VERSION%%.*}
-	VERSION_MINOR=${VERSION##*.}
-	vermajmin=${VERSION#*.}
-	VERSION_MAJOR=${vermajmin%.*}
-	if [ "$vermajmin" = "$VERSION_MAJOR" ] ; then
-		# we don't actually HAVE a minor version
-		VERSION_MINOR=""
-	fi
+  VERSION_SUPER=${VERSION%%.*}
+  VERSION_MINOR=${VERSION##*.}
+  vermajmin=${VERSION#*.}
+  VERSION_MAJOR=${vermajmin%.*}
+  if [ "$vermajmin" = "$VERSION_MAJOR" ]; then
+    # we don't actually HAVE a minor version
+    VERSION_MINOR=""
+  fi
 }
 
 # only creates a file if it does not already exist!!
 # will not overwrite an existing file
 createBldNumFile() {
-	filename="$1"
-	if [ ! -n "$filename" ] ; then
-		return 1
-	fi
-	if [ ! -e "$filename" ] ; then
-		/bin/echo "Could not find $filename"
-		BLDIR=${filename%/*}
-		if [ "$BLDIR" != "$filename" ] ; then
-			if [ ! -d $BLDIR ]; then
-				echo "$BLDIR directory does not exist... aborting" >&2
-				return 1
-			fi
-		fi
-		/bin/echo "   Creating it."
-		PRODNAME=" Unknown product" # yes, the initial space is deliberate
-		PKGNAME="unknown_pkg"
-		VERSION="0.0.0"
-		parseVersion
-		BUILDNUM="0"
-		EPOCH="0"
-		BUILDHOST=`/bin/uname -a | /bin/awk '{ print $2}'`
-		BUILDDATE=`/bin/date`
-		writeBldNumFile "$filename"
-	fi
-	unset filename
+  filename="$1"
+  if [ ! -n "$filename" ]; then
+    return 1
+  fi
+  if [ ! -e "$filename" ]; then
+    /bin/echo "Could not find $filename"
+    BLDIR=${filename%/*}
+    if [ "$BLDIR" != "$filename" ]; then
+      if [ ! -d $BLDIR ]; then
+        echo "$BLDIR directory does not exist... aborting" >&2
+        return 1
+      fi
+    fi
+    /bin/echo "   Creating it."
+    PRODNAME=" Unknown product" # yes, the initial space is deliberate
+    PKGNAME="unknown_pkg"
+    VERSION="0.0.0"
+    parseVersion
+    BUILDNUM="0"
+    EPOCH="0"
+    BUILDHOST=$(/bin/uname -a | /bin/awk '{ print $2}')
+    BUILDDATE=$(/bin/date)
+    writeBldNumFile "$filename"
+  fi
+  unset filename
 }
 
 loadBldNumFile() {
-	filename="$1"
-	if [ ! -e "$filename" ] ; then
-		return 1
-	fi
+  filename="$1"
+  if [ ! -e "$filename" ]; then
+    return 1
+  fi
 
-	PRODNAME=`/bin/grep ^ProductName "$filename" | /bin/cut -d: -f2`
-	PKGNAME=`/bin/grep ^PkgName "$filename" | /bin/awk '{print $2}'`
-	VERSION=`/bin/grep ^Version "$filename" | /bin/awk '{print $2}'`
-	BUILDNUM=`/bin/grep ^BuildNumber "$filename" | /bin/awk '{print $2}'`
-	EPOCH=`/bin/grep "^Epoch" "$filename" | /bin/awk '{print $2}'`
-	unset filename
+  PRODNAME=$(/bin/grep ^ProductName "$filename" | /bin/cut -d: -f2)
+  PKGNAME=$(/bin/grep ^PkgName "$filename" | /bin/awk '{print $2}')
+  VERSION=$(/bin/grep ^Version "$filename" | /bin/awk '{print $2}')
+  BUILDNUM=$(/bin/grep ^BuildNumber "$filename" | /bin/awk '{print $2}')
+  EPOCH=$(/bin/grep "^Epoch" "$filename" | /bin/awk '{print $2}')
+  unset filename
 }
 
 incrSuper() {
-	echo -e "\nIncrementing version super...\n"
-	let VERSION_SUPER=$VERSION_SUPER+1
-	VERSION_MAJOR=0
-	VERSION_MINOR=0
-	let BUILDNUM=1
-	let EPOCH=$EPOCH+1
+  echo -e "\nIncrementing version super...\n"
+  let VERSION_SUPER=$VERSION_SUPER+1
+  VERSION_MAJOR=0
+  VERSION_MINOR=0
+  let BUILDNUM=1
+  let EPOCH=$EPOCH+1
 }
 
 incrMajor() {
-	echo -e "\nIncrementing version major...\n"
-	let VERSION_MAJOR=$VERSION_MAJOR+1
-	VERSION_MINOR=0
-	let BUILDNUM=1
-	let EPOCH=$EPOCH+1
+  echo -e "\nIncrementing version major...\n"
+  let VERSION_MAJOR=$VERSION_MAJOR+1
+  VERSION_MINOR=0
+  let BUILDNUM=1
+  let EPOCH=$EPOCH+1
 }
 
 incrMinor() {
-	set -x -a -v
-	echo -e "\nIncrementing version minor...\n"
-	if [ -z "VERSION_MINOR" ]; then
-		VERSION_MINOR=0
-	else
-		let VERSION_MINOR=$VERSION_MINOR+1
-	fi
-	let BUILDNUM=1
-	let EPOCH=$EPOCH+1
-	set +x +a +v
+  set -x -a -v
+  echo -e "\nIncrementing version minor...\n"
+  if [ -z "VERSION_MINOR" ]; then
+    VERSION_MINOR=0
+  else
+    let VERSION_MINOR=$VERSION_MINOR+1
+  fi
+  let BUILDNUM=1
+  let EPOCH=$EPOCH+1
+  set +x +a +v
 }
 
 incrBuild() {
-	echo -e "\nIncrementing build number...\n";
-	let BUILDNUM=$BUILDNUM+1
-	let EPOCH=$EPOCH+1
+  echo -e "\nIncrementing build number...\n"
+  let BUILDNUM=$BUILDNUM+1
+  let EPOCH=$EPOCH+1
 }
 
 usage() {
-	echo -e "USAGE:\n\t$0 super|major|minor|build [alternate buildnumber.txt file]"
+  echo -e "USAGE:\n\t$0 super|major|minor|build [alternate buildnumber.txt file]"
 }
 #############################################################################################
 # main
 #    (Only execute the following if we were called by our real name - i.e. as a
 #     main script. Otherwise assume we've been sourced for testing of the functions.)
 #
-if [ ${0##*/} == "increment_build.sh" ] ; then
-	echo $@
+if [ ${0##*/} == "increment_build.sh" ]; then
+  echo $@
 
-	if [ -z "$1" ] || [ "$1" != "major" ] \
-		&& [ "$1" != "minor" ] && [ "$1" != "build" ]\
-		&& [ "$1" != "super" ]; then
-		/bin/echo -e "\nERROR!  Invalid or missing parameter."
-		usage
-		exit 1
-	fi
-	opt="$1"
-	if [ $# -lt 2 ]; then
-		BUILDNUM_TXT=$(getBldNumFilename)
-	else
-		BUILDNUM_TXT=$(getBldNumFilename $2)
-	fi
-	createBldNumFile $BUILDNUM_TXT
-	loadBldNumFile $BUILDNUM_TXT
-	
-	VERSION_SUPER=${VERSION%%.*}
-	VERSION_MINOR=${VERSION##*.}
-	vertmp=${VERSION#*.}
-	VERSION_MAJOR=${vertmp%.*}
-	case $opt in
-	"super") 
-		incrSuper
-		;;
-	"major")
-		incrMajor
-		;;
-	"minor")
-		incrMinor
-		;;
-	"build")
-		incrBuild
-		;;
-	*)
-		echo "ERROR: Unknown option \"$opt\""
-		usage
-		exit 1
-		;;
-	esac
+  if [ -z "$1" ] || [ "$1" != "major" ] \
+    && [ "$1" != "minor" ] && [ "$1" != "build" ] \
+    && [ "$1" != "super" ]; then
+    /bin/echo -e "\nERROR!  Invalid or missing parameter."
+    usage
+    exit 1
+  fi
+  opt="$1"
+  if [ $# -lt 2 ]; then
+    BUILDNUM_TXT=$(getBldNumFilename)
+  else
+    BUILDNUM_TXT=$(getBldNumFilename $2)
+  fi
+  createBldNumFile $BUILDNUM_TXT
+  loadBldNumFile $BUILDNUM_TXT
 
-	BUILDHOST=`/bin/uname -a | /bin/awk '{ print $2}'`
-	BUILDDATE=`/bin/date`
-	
-	writeBldNumFile ${BUILDNUM_TXT}
+  VERSION_SUPER=${VERSION%%.*}
+  VERSION_MINOR=${VERSION##*.}
+  vertmp=${VERSION#*.}
+  VERSION_MAJOR=${vertmp%.*}
+  case $opt in
+    "super")
+      incrSuper
+      ;;
+    "major")
+      incrMajor
+      ;;
+    "minor")
+      incrMinor
+      ;;
+    "build")
+      incrBuild
+      ;;
+    *)
+      echo "ERROR: Unknown option \"$opt\""
+      usage
+      exit 1
+      ;;
+  esac
+
+  BUILDHOST=$(/bin/uname -a | /bin/awk '{ print $2}')
+  BUILDDATE=$(/bin/date)
+
+  writeBldNumFile ${BUILDNUM_TXT}
 fi

--- a/sample/wrapper_multipleTest.sh
+++ b/sample/wrapper_multipleTest.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -e
+
+# Load jshu wrapper
+source ../wrapper.sh --load \
+  'Name of the main stage' \
+  'Name of the tests suite of this sequence'
+
+# Test 1
+Test "Test 1 - Echo" <<§
+
+  # Test
+  echo 'Test'
+§
+
+# Test 2
+Test "Test 2 - Falsy" <<§
+
+  # Test
+  echo 'OK'
+  [ ${?} -eq 0 ]
+  echo 'NOK'
+  [ ${?} -eq 1 ]
+  echo 'NOT VISIBLE'
+§
+
+# Test 3
+Test "Test 3 - Heredoc" <<§
+
+  # Test
+  bash <<EOF
+echo 'Nested bash'
+ls -la /root/
+EOF
+§
+
+# Test 4
+Test "Test 4 - Exit" <<§
+
+  # Test
+  exit 1
+§
+
+# Test 5
+Test "Test 5 - Return" <<§
+
+  # Test
+  return 1
+§
+
+# Test 6
+Test "Test 6 - Environment" <<§
+
+  # Test
+  echo "${jshu_ts_startTime}"
+§
+
+# Test 7
+Test "Test 7 - Variables expanded" <<§
+
+  # Test
+  path='/root/'
+  ls -la "${path}"
+§
+
+# Test 8
+Test "Test 8 - Variables evaluated" <<\§
+
+  # Test
+  path='/root/'
+  ls -la "${path}"
+§
+
+# Finish jshu wrapper
+source ../wrapper.sh --finish

--- a/sample/wrapper_singleTest.sh
+++ b/sample/wrapper_singleTest.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# First standalone test
+source ../wrapper.sh --test \
+  'Name of the main stage' \
+  'Name of the tests suite of this sequence' \
+  'Name of the first single test' <<\§
+
+  # Test
+  echo 'Test'
+
+  # Test
+  ls -la /root/
+§
+
+# Second standalone test
+source ../wrapper.sh --test \
+  'Name of the main stage' \
+  'Name of the tests suite of this sequence' \
+  'Name of the second single test' <<\§
+
+  # Test
+  echo 'Test'
+
+  # Test
+  ls -la /missing/
+§
+
+# Third standalone test
+source ../wrapper.sh --test \
+  'Name of the main stage' \
+  'Name of the tests suite of this sequence' \
+  'Name of the third single test' <<\§
+
+  # Test
+  echo 'Test'
+§

--- a/tests/adhocFunctionNamesTest.sh
+++ b/tests/adhocFunctionNamesTest.sh
@@ -1,33 +1,31 @@
-#!/bin/bash 
+#!/bin/bash
 
 # source the unit test for scripts functions
 . ../jshutest.inc
 
 jshuSetup() {
-    # set this variable to a space-delimited list of function names
-    # that you want to run as tests.
-    jshuTestFunctions="AlwaysPass AlwaysPass2"
+  # set this variable to a space-delimited list of function names
+  # that you want to run as tests.
+  jshuTestFunctions="AlwaysPass AlwaysPass2"
 }
 
 jshuTeardown() {
-    return 0
+  return 0
 }
 
 ##############################################################
 # unit test functions
 AlwaysPass() {
-	return ${jshuPASS}
+  return ${jshuPASS}
 }
 
 AlwaysPass2() {
-	return ${jshuPASS}
+  return ${jshuPASS}
 }
 
 NormalFuncNameTest() {
-    return ${jshuPASS}
+  return ${jshuPASS}
 }
-
-
 
 ##############################################################
 # main

--- a/tests/fail_FailAbortTest.sh
+++ b/tests/fail_FailAbortTest.sh
@@ -1,24 +1,21 @@
-#!/bin/bash 
+#!/bin/bash
 
 # source the unit test for scripts functions
 . ../jshutest.inc
 
 # see to it that the setup function fails
 jshuSetup() {
-    return 0
+  return 0
 }
 ##############################################################
 # unit test functions
 AbortingTest() {
-    return ${jshuFAILABORT}
+  return ${jshuFAILABORT}
 }
 
 AlwaysPassTest() {
-	return ${jshuPASS}
+  return ${jshuPASS}
 }
-
-
-
 
 ##############################################################
 # main

--- a/tests/fail_adhocFunctionNamesTest.sh
+++ b/tests/fail_adhocFunctionNamesTest.sh
@@ -1,33 +1,31 @@
-#!/bin/bash 
+#!/bin/bash
 
 # source the unit test for scripts functions
 . ../jshutest.inc
 
 jshuSetup() {
-    # set this variable to a space-delimited list of function names
-    # that you want to run as tests.
-    jshuTestFunctions="AlwaysPass Imaginary AlwaysPass2"
+  # set this variable to a space-delimited list of function names
+  # that you want to run as tests.
+  jshuTestFunctions="AlwaysPass Imaginary AlwaysPass2"
 }
 
 jshuTeardown() {
-    return 0
+  return 0
 }
 
 ##############################################################
 # unit test functions
 AlwaysPass() {
-	return ${jshuPASS}
+  return ${jshuPASS}
 }
 
 AlwaysPass2() {
-	return ${jshuPASS}
+  return ${jshuPASS}
 }
 
 NormalFuncNameTest() {
-    return ${jshuPASS}
+  return ${jshuPASS}
 }
-
-
 
 ##############################################################
 # main

--- a/tests/fail_jshuSetupTest.sh
+++ b/tests/fail_jshuSetupTest.sh
@@ -1,20 +1,17 @@
-#!/bin/bash 
+#!/bin/bash
 
 # source the unit test for scripts functions
 . ../jshutest.inc
 
 # see to it that the setup function fails
 jshuSetup() {
-    return 1
+  return 1
 }
 ##############################################################
 # unit test functions
 AlwaysPassTest() {
-	return ${jshuPASS}
+  return ${jshuPASS}
 }
-
-
-
 
 ##############################################################
 # main

--- a/tests/fail_jshuTeardownTest.sh
+++ b/tests/fail_jshuTeardownTest.sh
@@ -1,24 +1,21 @@
-#!/bin/bash 
+#!/bin/bash
 
 # source the unit test for scripts functions
 . ../jshutest.inc
 
 jshuSetup() {
-    return 0
+  return 0
 }
 # see to it that the teardown function fails
 jshuTeardown() {
-    return 1
+  return 1
 }
 
 ##############################################################
 # unit test functions
 AlwaysPassTest() {
-	return ${jshuPASS}
+  return ${jshuPASS}
 }
-
-
-
 
 ##############################################################
 # main

--- a/tests/wrapper_unfinishedTest.sh
+++ b/tests/wrapper_unfinishedTest.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Load jshu wrapper
+source ../wrapper.sh --load \
+  'Name of the main stage' \
+  'Unfinished test suite handled as failure'
+
+# Test 1
+Test "Test 1 - Echo" <<§
+
+  # Test
+  echo 'Test'
+§

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Variables
+jshu=$(dirname $(readlink -f "${BASH_SOURCE:-${0}}"))
+result=1
+
+# Wrapper modes
+case "${1}" in
+
+# Load mode
+--load)
+  # Configure bash
+  set +e
+  set +x
+
+  # Import jshu
+  source "${jshu}/jshutest.inc"
+
+  # Configure tests package
+  jshu_pkgname="${2}"
+
+  # Start tests
+  if [ ! -z "${WORKSPACE}" ] && [ -z "${BUILDDIR}" ]; then
+    BUILDDIR=${WORKSPACE} jshuInit "${3}"
+  else
+    jshuInit "${3}"
+  fi
+
+  # Declare Test function
+  function Test() {
+    # Variables
+    local result
+
+    # Create test runner
+    source <(
+      cat <<END_OF_TEST
+function TestRunner()
+{
+  # Test title
+  test_title="${1}";
+
+  # Test executions
+  $(cat)
+}
+END_OF_TEST
+    )
+
+    # Run test
+    jshu_run_test TestRunner
+    result=${?}
+
+    # Cleanup
+    unset TestRunner
+
+    # Result
+    return "${result}"
+  }
+
+  # Result
+  result=0
+  ;;
+
+# Test mode
+--test)
+  # Load jshu wrapper
+  source "${jshu}/wrapper.sh" --load "${2}" "${3}"
+
+  # Add test name to the file name
+  jshu_test_tag=${4//./_}
+  jshu_test_tag=${jshu_test_tag// /_}
+  jshu_suite=${jshu_suite}.${jshu_test_tag}
+
+  # Run single test
+  Test "${4}" <<§
+  $(cat)
+§
+  result=${?}
+
+  # Finish jshu wrapper
+  source "${jshu}/wrapper.sh" --finish
+  ;;
+
+# Finish mode
+--finish)
+  # Finalize tests
+  jshuFinalize
+  result=${?}
+  ;;
+
+esac
+
+# Result
+(exit "${result}")

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -21,9 +21,9 @@ case "${1}" in
 
   # Start tests
   if [ ! -z "${WORKSPACE}" ] && [ -z "${BUILDDIR}" ]; then
-    BUILDDIR=${WORKSPACE} jshuInit "${3}"
+    BUILDDIR=${WORKSPACE} jshuInit "${3}" "${4}"
   else
-    jshuInit "${3}"
+    jshuInit "${3}" "${4}"
   fi
 
   # Declare Test function
@@ -62,13 +62,12 @@ END_OF_TEST
 
 # Test mode
 --test)
-  # Load jshu wrapper
-  source "${jshu}/wrapper.sh" --load "${2}" "${3}"
-
-  # Add test name to the file name
+  # Prepare test name for file name
   jshu_test_tag=${4//./_}
   jshu_test_tag=${jshu_test_tag// /_}
-  jshu_suite=${jshu_suite}.${jshu_test_tag}
+
+  # Load jshu wrapper
+  source "${jshu}/wrapper.sh" --load "${2}" "${3}" "${jshu_test_tag}"
 
   # Run single test
   Test "${4}" <<§


### PR DESCRIPTION
This merge request is a proposal of various evolutions I made to jshu over the last year.
The XML outputs used to be parsed by Jenkins and now by GitLab CI and Allure Test Report.

**Version 1.0.0-20**
* Add tests duration in tests reports
* Use the results/xunit path for XML results
* Refactor XML with timestamps, failures, hostname
* Return error level in finish steps
* Use 'Tests.*' naming for XML result files
* Always adapt the package name to a file name
* Improve tests outputs with colors and spacing
* Trim extended and colored chars from execution outputs
* Extract jshu_errmsg and test_title from the output
* Handle errors inside test functions and verbose output
* Implement optional "test_title" variable in test
* Support passing a formatted tests suite name
* Apply shfmt formatting Bash codestyle to all files
* Enforce faulty result file before proper jshuFinalize call
* Support wrapper.sh --test handlings with enforced failures

**Example GitLab CI tests output:** [jshu.pdf](https://github.com/Shadowfen/jshu/files/4014444/jshu.pdf)
